### PR TITLE
Improve predict_speed, add set_params method, readability

### DIFF
--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -42,6 +42,7 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         return probs
 
     def set_params(self, **params):
+        self.clf.set_params(**params)
         for _,clf in self.clfs.items():
             clf.set_params(**params)
 

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -31,13 +31,14 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         return np.argmax( self.predict_proba(X), axis=1 )
 
     def predict_proba(self,X):
-        predicted = np.vstack([self.clfs[k].predict_proba(X)[:,1] for k in self.clfs]).T
+        predicted = [self.clfs[k].predict_proba(X)[:,1].reshape(-1,1) for k in self.clfs]
 
-        p_x_first = 1-predicted[:, :1]
-        p_x_last  = predicted[:, -1:]
-        p_x_middle= predicted[:, 0:-1] - predicted[:, 1:]
+        p_x_first = 1-predicted[0]
+        p_x_last  = predicted[-1]
+        p_x_middle= [predicted[i] - predicted[i+1] for i in range(len(predicted) - 1)]
+        
+        probs = np.hstack([p_x_first, *p_x_middle, p_x_last])
 
-        probs = np.hstack([p_x_first, p_x_middle, p_x_last])
         return probs
 
     def set_params(self, **params):

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -31,19 +31,14 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         return np.argmax( self.predict_proba(X), axis=1 )
 
     def predict_proba(self,X):
-        clfs_predict = {k:self.clfs[k].predict_proba(X) for k in self.clfs}
+        predicted = np.vstack([self.clfs[k].predict_proba(X)[:,1] for k in self.clfs]).T
 
-        predicted = []
+        p_x_first = 1-predicted[:, :1]
+        p_x_last  = predicted[:, -1:]
+        p_x_middle= predicted[:, 0:-1] - predicted[:, 1:]
 
-        for i,y in enumerate(self.uniques_class):
-            if i == 0:
-                # V1 = 1 - Pr(y > V1)
-                predicted.append(1 - clfs_predict[y][:, 1])
-            elif y in clfs_predict:
-                #Vi = Pr(y>Vi-1)- Pr(y > Vi)
-                predicted.append(clfs_predict[y-1][:,1] - clfs_predict[y][:,1])
-            else:
-                predicted.append(clfs_predict[y-1][:,1])
+        probs = np.hstack([p_x_first, p_x_middle, p_x_last])
+        return probs
 
         return np.vstack(predicted).T
 

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -14,18 +14,19 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
     def __init__(self,clf):
         self.clf = clf
         self.clfs = {}
+        self.uniques_class = None
 
 
     def fit(self,X,y):
-            self.uniques_class = np.sort(np.unique(y))
-            if self.uniques_class.shape[0] > 2:
-                for i in range(self.uniques_class.shape[0]-1):
-                    #binary_y = (y > self.uniques_class[1]).astype(np.uint8)
+        self.uniques_class = np.sort(np.unique(y))
+        assert self.uniques_class.shape[0] < 3, f'OrdinalClassifier needs at least 3 classes, only {self.uniques_class.shape[0]} found'
 
-                    binary_y = (y > self.uniques_class[i]).astype(np.uint8)
-                    clf = clone(self.clf)
-                    clf.fit(X,binary_y)
-                    self.clfs[i] = clf
+        for i in range(self.uniques_class.shape[0]-1):
+            binary_y = (y > self.uniques_class[i]).astype(np.uint8)
+            
+            clf = clone(self.clf)
+            clf.fit(X,binary_y)
+            self.clfs[i] = clf
 
     def predict(self,X):
         return np.argmax( self.predict_proba(X), axis=1 )

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -40,8 +40,8 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         probs = np.hstack([p_x_first, p_x_middle, p_x_last])
         return probs
 
-    def set_params(**params):
-        for _,clf in self.clfs:
+    def set_params(self, **params):
+        for _,clf in self.clfs.items():
             clf.set_params(**params)
 
 

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -41,6 +41,8 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         probs = np.hstack([p_x_first, p_x_middle, p_x_last])
         return probs
 
-        return np.vstack(predicted).T
+    def set_params(**params):
+        for _,clf in self.clfs:
+            clf.set_params(**params)
 
 

--- a/Ordinal_Classifier.py
+++ b/Ordinal_Classifier.py
@@ -16,10 +16,9 @@ class OrdinalClassifier(BaseEstimator, ClassifierMixin):
         self.clfs = {}
         self.uniques_class = None
 
-
     def fit(self,X,y):
         self.uniques_class = np.sort(np.unique(y))
-        assert self.uniques_class.shape[0] < 3, f'OrdinalClassifier needs at least 3 classes, only {self.uniques_class.shape[0]} found'
+        assert self.uniques_class.shape[0] >= 3, f'OrdinalClassifier needs at least 3 classes, only {self.uniques_class.shape[0]} found'
 
         for i in range(self.uniques_class.shape[0]-1):
             binary_y = (y > self.uniques_class[i]).astype(np.uint8)

--- a/performance_comparison.ipynb
+++ b/performance_comparison.ipynb
@@ -1,0 +1,662 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb578d45-9ff2-4400-8543-8597eb984a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np \n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a205be21-3cc6-4b1c-9b7b-9d84f9e9b6da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "from sklearn.base import clone, BaseEstimator, ClassifierMixin\n",
+    "from sklearn.utils.validation import check_X_y, check_is_fitted, check_array\n",
+    "from sklearn.utils.multiclass import check_classification_targets\n",
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "import numpy as np\n",
+    "\n",
+    "class OrdinalClassifier(BaseEstimator, ClassifierMixin):\n",
+    "    #https://towardsdatascience.com/simple-trick-to-train-an-ordinal-regression-with-any-classifier-6911183d2a3c\n",
+    "    \"\"\"\n",
+    "    A classifier that can be trained on a range of classes.\n",
+    "    @param classifier: A scikit-learn classifier.\n",
+    "    \"\"\"\n",
+    "    def __init__(self,clf):\n",
+    "        self.clf = clf\n",
+    "        self.clfs = {}\n",
+    "\n",
+    "    def fit(self,X,y, **kwargs):\n",
+    "        self.uniques_class = np.sort(np.unique(y))\n",
+    "\n",
+    "        if self.uniques_class.shape[0] > 2:\n",
+    "            for i in range(self.uniques_class.shape[0]-1):\n",
+    "                #binary_y = (y > self.uniques_class[1]).astype(np.uint8)\n",
+    "\n",
+    "                binary_y = (y > self.uniques_class[i]).astype(np.uint8)\n",
+    "                clf = clone(self.clf)\n",
+    "                clf.fit(X,binary_y, **kwargs)\n",
+    "                self.clfs[i] = clf\n",
+    "\n",
+    "    def predict(self,X):\n",
+    "        return np.argmax( self.predict_proba(X), axis=1 )\n",
+    "\n",
+    "    def predict_proba(self,X):\n",
+    "        h = [self.clfs[k].predict_proba(X)[:,1].reshape(-1,1) for k in self.clfs]\n",
+    "\n",
+    "        p_x_first = 1-h[0]\n",
+    "        p_x_last  = h[-1]\n",
+    "        p_x_middle= [h[i] - h[i+1] for i in range(len(h) - 1)]\n",
+    "        \n",
+    "        probs = np.hstack([p_x_first, *p_x_middle, p_x_last])\n",
+    "\n",
+    "        return probs\n",
+    "    \n",
+    "    def set_params(**params):\n",
+    "        # print(params)\n",
+    "        self.clf.set_params(**params)\n",
+    "    \n",
+    "    \n",
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "from sklearn.base import clone, BaseEstimator, ClassifierMixin\n",
+    "from sklearn.utils.validation import check_X_y, check_is_fitted, check_array\n",
+    "from sklearn.utils.multiclass import check_classification_targets\n",
+    "from sklearn.neighbors import KNeighborsClassifier\n",
+    "import numpy as np\n",
+    "\n",
+    "class OrdinalClassifier(BaseEstimator, ClassifierMixin):\n",
+    "    #https://towardsdatascience.com/simple-trick-to-train-an-ordinal-regression-with-any-classifier-6911183d2a3c\n",
+    "    \"\"\"\n",
+    "    A classifier that can be trained on a range of classes.\n",
+    "    @param classifier: A scikit-learn classifier.\n",
+    "    \"\"\"\n",
+    "    def __init__(self,clf):\n",
+    "        self.clf = clf\n",
+    "        self.clfs = {}\n",
+    "\n",
+    "\n",
+    "    def fit(self,X,y):\n",
+    "            self.uniques_class = np.sort(np.unique(y))\n",
+    "            if self.uniques_class.shape[0] > 2:\n",
+    "                for i in range(self.uniques_class.shape[0]-1):\n",
+    "                    #binary_y = (y > self.uniques_class[1]).astype(np.uint8)\n",
+    "\n",
+    "                    binary_y = (y > self.uniques_class[i]).astype(np.uint8)\n",
+    "                    clf = clone(self.clf)\n",
+    "                    clf.fit(X,binary_y)\n",
+    "                    self.clfs[i] = clf\n",
+    "\n",
+    "    def predict(self,X):\n",
+    "        return np.argmax( self.predict_proba(X), axis=1 )\n",
+    "\n",
+    "    def predict_proba(self,X):\n",
+    "        clfs_predict = {k:self.clfs[k].predict_proba(X) for k in self.clfs}\n",
+    "\n",
+    "        predicted = []\n",
+    "\n",
+    "        for i,y in enumerate(self.uniques_class):\n",
+    "            if i == 0:\n",
+    "                # V1 = 1 - Pr(y > V1)\n",
+    "                predicted.append(1 - clfs_predict[y][:, 1])\n",
+    "            elif y in clfs_predict:\n",
+    "                #Vi = Pr(y>Vi-1)- Pr(y > Vi)\n",
+    "                predicted.append(clfs_predict[y-1][:,1] - clfs_predict[y][:,1])\n",
+    "            else:\n",
+    "                predicted.append(clfs_predict[y-1][:,1])\n",
+    "\n",
+    "        return np.vstack(predicted).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "13a8de57-5c4a-4583-8666-572a46193adf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>fixed acidity</th>\n",
+       "      <th>volatile acidity</th>\n",
+       "      <th>citric acid</th>\n",
+       "      <th>residual sugar</th>\n",
+       "      <th>chlorides</th>\n",
+       "      <th>free sulfur dioxide</th>\n",
+       "      <th>total sulfur dioxide</th>\n",
+       "      <th>density</th>\n",
+       "      <th>pH</th>\n",
+       "      <th>sulphates</th>\n",
+       "      <th>alcohol</th>\n",
+       "      <th>quality</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8.0</td>\n",
+       "      <td>0.500</td>\n",
+       "      <td>0.39</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>0.073</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>39.0</td>\n",
+       "      <td>0.99572</td>\n",
+       "      <td>3.33</td>\n",
+       "      <td>0.77</td>\n",
+       "      <td>12.1</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>9.3</td>\n",
+       "      <td>0.300</td>\n",
+       "      <td>0.73</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>0.092</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>0.99854</td>\n",
+       "      <td>3.32</td>\n",
+       "      <td>0.67</td>\n",
+       "      <td>12.8</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7.1</td>\n",
+       "      <td>0.510</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>0.059</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.99660</td>\n",
+       "      <td>3.52</td>\n",
+       "      <td>0.73</td>\n",
+       "      <td>11.3</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>8.1</td>\n",
+       "      <td>0.870</td>\n",
+       "      <td>0.22</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>0.084</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>0.99730</td>\n",
+       "      <td>3.20</td>\n",
+       "      <td>0.53</td>\n",
+       "      <td>9.8</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>8.5</td>\n",
+       "      <td>0.360</td>\n",
+       "      <td>0.30</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>0.079</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>0.99444</td>\n",
+       "      <td>3.20</td>\n",
+       "      <td>1.36</td>\n",
+       "      <td>9.5</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3194</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>0.510</td>\n",
+       "      <td>0.13</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>0.076</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>0.99574</td>\n",
+       "      <td>3.42</td>\n",
+       "      <td>0.75</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3195</th>\n",
+       "      <td>6.8</td>\n",
+       "      <td>0.620</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>1.9</td>\n",
+       "      <td>0.068</td>\n",
+       "      <td>28.0</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>0.99651</td>\n",
+       "      <td>3.42</td>\n",
+       "      <td>0.82</td>\n",
+       "      <td>9.5</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3196</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>0.600</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.090</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>0.99490</td>\n",
+       "      <td>3.45</td>\n",
+       "      <td>0.58</td>\n",
+       "      <td>10.5</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3197</th>\n",
+       "      <td>5.9</td>\n",
+       "      <td>0.550</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>0.062</td>\n",
+       "      <td>39.0</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>0.99512</td>\n",
+       "      <td>3.52</td>\n",
+       "      <td>0.76</td>\n",
+       "      <td>11.2</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3198</th>\n",
+       "      <td>5.9</td>\n",
+       "      <td>0.645</td>\n",
+       "      <td>0.12</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.075</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>0.99547</td>\n",
+       "      <td>3.57</td>\n",
+       "      <td>0.71</td>\n",
+       "      <td>10.2</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3199 rows × 12 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      fixed acidity  volatile acidity  citric acid  residual sugar  chlorides  \\\n",
+       "0               8.0             0.500         0.39             2.2      0.073   \n",
+       "1               9.3             0.300         0.73             2.3      0.092   \n",
+       "2               7.1             0.510         0.03             2.1      0.059   \n",
+       "3               8.1             0.870         0.22             2.6      0.084   \n",
+       "4               8.5             0.360         0.30             2.3      0.079   \n",
+       "...             ...               ...          ...             ...        ...   \n",
+       "3194            6.3             0.510         0.13             2.3      0.076   \n",
+       "3195            6.8             0.620         0.08             1.9      0.068   \n",
+       "3196            6.2             0.600         0.08             2.0      0.090   \n",
+       "3197            5.9             0.550         0.10             2.2      0.062   \n",
+       "3198            5.9             0.645         0.12             2.0      0.075   \n",
+       "\n",
+       "      free sulfur dioxide  total sulfur dioxide  density    pH  sulphates  \\\n",
+       "0                    30.0                  39.0  0.99572  3.33       0.77   \n",
+       "1                    30.0                  67.0  0.99854  3.32       0.67   \n",
+       "2                     3.0                  12.0  0.99660  3.52       0.73   \n",
+       "3                    11.0                  65.0  0.99730  3.20       0.53   \n",
+       "4                    10.0                  45.0  0.99444  3.20       1.36   \n",
+       "...                   ...                   ...      ...   ...        ...   \n",
+       "3194                 29.0                  40.0  0.99574  3.42       0.75   \n",
+       "3195                 28.0                  38.0  0.99651  3.42       0.82   \n",
+       "3196                 32.0                  44.0  0.99490  3.45       0.58   \n",
+       "3197                 39.0                  51.0  0.99512  3.52       0.76   \n",
+       "3198                 32.0                  44.0  0.99547  3.57       0.71   \n",
+       "\n",
+       "      alcohol  quality  \n",
+       "0        12.1        6  \n",
+       "1        12.8        6  \n",
+       "2        11.3        7  \n",
+       "3         9.8        5  \n",
+       "4         9.5        6  \n",
+       "...       ...      ...  \n",
+       "3194     11.0        6  \n",
+       "3195      9.5        6  \n",
+       "3196     10.5        5  \n",
+       "3197     11.2        6  \n",
+       "3198     10.2        5  \n",
+       "\n",
+       "[3199 rows x 12 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv('data/train.csv', index_col='Id')\n",
+    "X_compete = pd.read_csv('data/test.csv', index_col='Id')\n",
+    "\n",
+    "X, y = df.drop(columns=['quality']), df.quality\n",
+    "y = y-3\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8dcb20f-fcbb-48cc-a630-eae86fe1f3f0",
+   "metadata": {},
+   "source": [
+    "# New Encoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "6c9898a7-f0bc-49b3-a395-9a8f919700ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mamiglia/.local/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1334: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, msg_start, len(result))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cohen = 0.48285419301389243 \n",
+      "Recall = 0.5892466395748671 \n",
+      "Precision = 0.5552267609453678 \n",
+      "Accuracy = 0.5892466395748671\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAGwCAYAAACuFMx9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAABZpElEQVR4nO3deVwU9f8H8Ncsy30sh5yCqHmiIqZFpKWmiWUeaYdGhWb6zSCvr6b+8jalrNQ00w7z6CupHZpaqaR55Y1HHogHKIiccoMs7O78/iBXNzWBZRl25/V8POZRO/OZ2fcHd/a9n2NmBFEURRAREZHFUkgdABEREZkWkz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMREVk4JnsiIiILp5Q6AGPodDpcv34dzs7OEARB6nCIiKiaRFFEUVER/Pz8oFCYrv1ZVlaG8vJyo49jY2MDOzu7Woiobpl1sr9+/ToCAgKkDoOIiIyUmpoKf39/kxy7rKwMTQKdkJGlNfpYPj4+SE5ONruEb9bJ3tnZGQDQBc9CCWuJoyFTE5Rm/XGtMVFr/BeUWeLNPWVBgwrsx6/673NTKC8vR0aWFlfjG8PFuea9B4VFOgR2vILy8nIm+7p0q+teCWsoBSZ7SycIZv1xrTFRkOvUGiZ7Wfj7n7kuhmKdnAU4Odf8fXQw3+FieX57EhGR7GhFHbRG/IbUirraC6aOMdkTEZEs6CBCZ0SPkTH7Sk2u/YNERESywZY9ERHJgg46GNMRb9ze0mKyJyIiWdCKIrRGXOVhzL5SYzc+ERGRhWPLnoiIZEHOE/SY7ImISBZ0EKGVabJnNz4REZGFY8ueiIhkgd34REREFo6z8YmIiMhisWVPRESyoPt7MWZ/c8VkT0REsqA1cja+MftKjcmeiIhkQSvCyKfe1V4sdY1j9kRERBaOLXsiIpIFjtkTERFZOB0EaCEYtb+5Yjc+ERGRhWPLnoiIZEEnVi7G7G+umOyJiEgWtEZ24xuzr9TYjU9ERGTh2LInIiJZYMueqqXv0BysPnwOW5L+wqdbL6JlSKnUIdUJS69320eLMPObS1h79C9sS4lHWK/8+5Z9Z95VbEuJx4DhmXUXoAReisrE9rSTeGvWNalDqROW/hm/FznVWScKRi/mql4k+6VLl6Jx48aws7NDaGgojhw5InVI99W1Xx5GzriOtQt8EBXeAknn7DA3NgkqjwqpQzMpOdTbzkGH5HP2WDo14F/LPR6eh1YdSpCTYV1HkUmjRftS9Hn1BpLO2UkdSp2Qw2f8n+RYZ7mSPNmvX78e48ePx4wZM3D8+HG0b98e4eHhyMrKkjq0exo4MgfbYt2xY707Ui7aYfEkf6hvCggfkit1aCYlh3of263C6o8b4sB2t/uW8fAux6jZqZg/pgm0Feb7K/9B7By0mPTZVSx6NwBF+VZSh1Mn5PAZ/ye51flWN74xi7mSPNkvWLAAI0aMwLBhwxAUFITly5fDwcEB33zzjdSh3UVprUPz4FIc3+esXyeKAk7sc0ZQR8vt+pJrvf9JEERMXHQFP3zhjasX7KUOx6Si513DkZ0uOHHHv7klk+NnXI511kJh9GKuJI28vLwc8fHx6Nmzp36dQqFAz549cfDgwbvKq9VqFBYWGix1ycVdCyslkJ9tOK8xL0cJN09NncZSl+Ra73966e0MaLXAz994SR2KSXXtl4dmbW/imxhfqUOpM3L8jMuxzqKR4/Uix+xrJicnB1qtFt7e3gbrvb29kZGRcVf5mJgYqFQq/RIQ8O9jq0S1pVm7EvQfloVP/tsYMOOuvAfx9CvHqNlp+PCdQFSozbcVQ0SGzOrSuylTpmD8+PH614WFhXWa8AtzraDVAK7/+NXr1kCDvGyz+lNWi1zrfae2jxbDtYEG3x48rV9npQRGTL2G59/IQmTndhJGV3uatSuFm6cGS7cl6tdZKYF2j5Wg39AcPNekPXQ6y/uxI8fPuBzrLOdL7yT9F23QoAGsrKyQmWl4+VJmZiZ8fHzuKm9rawtbW9u6Cu8umgoFLv7lgA5dinBwmwpA5ThuSJdibF7lIVlcpibXet9p548eOLHPxWDd3P9dxM6f3BG3oYFEUdW+k/udMfKplgbr/rsgBamX7bBhqZdFJnpAnp9xOdZZKyqgFWveY2XOz7OXNNnb2NigY8eO2LlzJwYMGAAA0Ol02LlzJ6Kjo6UM7b5++rIBJixKxYVTDkg84YDnR2TDzkGHHevcpQ7NpORQbzsHLfwaq/WvfQLUaBpUiqJ8JbKv26Ao3/B00VYIyMu2xrUky7k07WaJFa4mGk4+LCtVoCjv7vWWRg6f8X+SY53lSvK+mvHjxyMyMhKdOnXCo48+ikWLFqGkpATDhg2TOrR72rPZDSoPLV6fmAE3Tw2SztrjvYgmyM+x7Guu5VDvFsGlmL/hgv71f2ZU3kgm7nuPv8fqyZLJ4TP+T3Krsw4CdEZMVdPBfJv2giiKkkf/2Wef4aOPPkJGRgZCQkKwePFihIaGPnC/wsJCqFQqdEN/KAXL/HDSbYJS8t+mkhC1WqlDkIb0X01UBzRiBXbjZxQUFMDFxeXBO9TArVyx+a+H4Ohc8/tGlBRp0S/4skljNZV68e0ZHR1db7vtiYiIzF29SPZERESmZvwEPfPtbWKyJyIiWagcs6/5FSXG7Cs13jWDiIjIwrFlT0REsqAz8v725jwbn8meiIhkgWP2REREFk4HhWyvs+eYPRERkYVjy56IiGRBKwrQGvGYWmP2lRqTPRERyYLWyAl6WnbjExERUX3Flj0REcmCTlRAZ8RsfB1n4xMREdVv7MYnIiIii8WWPRERyYIOxs2o19VeKHWOyZ6IiGTB+JvqmG9nuPlGTkRERFXClj0REcmC8ffGN9/2MZM9ERHJgpyfZ89kT0REsiDnlr35Rk5ERERVwpY9ERHJgvE31THf9jGTPRERyYJOFKAz5jp7M37qnfn+TCEiIqIqYcueiIhkQWdkN74531SHyZ7MhsLNTeoQJCEWFUkdgiR0ZWVSh0AWxvin3plvsjffyImIiKhK2LInIiJZ0EKA1ogb4xizr9SY7ImISBbYjU9EREQWiy17IiKSBS2M64rX1l4odY7JnoiIZEHO3fhM9kREJAt8EA4RERHVKq1Wi2nTpqFJkyawt7fHQw89hDlz5kAURX0ZURQxffp0+Pr6wt7eHj179sTFixcNjpObm4uIiAi4uLjA1dUVw4cPR3FxcbViYbInIiJZEP9+nn1NF7Ga4/0ffvghli1bhs8++wwJCQn48MMPMX/+fCxZskRfZv78+Vi8eDGWL1+Ow4cPw9HREeHh4Si746ZSEREROHv2LOLi4rB161bs3bsXI0eOrFYs7MYnIiJZqOtu/AMHDqB///7o06cPAKBx48b47rvvcOTIEQCVrfpFixZh6tSp6N+/PwBgzZo18Pb2xqZNmzB48GAkJCRg27ZtOHr0KDp16gQAWLJkCZ599ll8/PHH8PPzq1IsbNkTERFVQ2FhocGiVqvvWe7xxx/Hzp07ceHCBQDAqVOnsH//fjzzzDMAgOTkZGRkZKBnz576fVQqFUJDQ3Hw4EEAwMGDB+Hq6qpP9ADQs2dPKBQKHD58uMoxs2VPRESyUFuPuA0ICDBYP2PGDMycOfOu8pMnT0ZhYSFatWoFKysraLVazJ07FxEREQCAjIwMAIC3t7fBft7e3vptGRkZ8PLyMtiuVCrh7u6uL1MVTPZERCQLWiOfendr39TUVLi4uOjX29ra3rP8hg0bsHbtWsTGxqJNmzY4efIkxo4dCz8/P0RGRtY4jppgsiciIqoGFxcXg2R/PxMnTsTkyZMxePBgAEC7du1w9epVxMTEIDIyEj4+PgCAzMxM+Pr66vfLzMxESEgIAMDHxwdZWVkGx9VoNMjNzdXvXxUcsyciIlm41Y1vzFIdpaWlUCgM06yVlRV0Oh0AoEmTJvDx8cHOnTv12wsLC3H48GGEhYUBAMLCwpCfn4/4+Hh9mV27dkGn0yE0NLTKsbBlT0REsqCDAjoj2rjV3bdv376YO3cuGjVqhDZt2uDEiRNYsGAB3njjDQCAIAgYO3Ys3n//fTRv3hxNmjTBtGnT4OfnhwEDBgAAWrdujd69e2PEiBFYvnw5KioqEB0djcGDB1d5Jj7AZE9ERGQSS5YswbRp0/D2228jKysLfn5++M9//oPp06fry7z77rsoKSnByJEjkZ+fjy5dumDbtm2ws7PTl1m7di2io6PRo0cPKBQKDBo0CIsXL65WLIJ45618zExhYSFUKhW6oT+UgrXU4ZCJWXl6Sh2CJMSiIqlDkITujpuKkOXSiBXYjZ9RUFBQpXHwmriVK0btGwhbp5rnCnVxBZY98ZNJYzUVtuyJiEgWauvSO3PEZE9ERLIgGvnUO5EPwiEiIqL6ii17IiKSBS0EaKv5MJt/7m+umOyJiEgWdKJx4+46s53Ozm58IiIii8eWfQ30HZqDF0Zlwd1Tg6Rz9vh8akMknnSQOiyTs/R6e3iVYdjYS+jU+QZs7bRIT7XHwultcPHcrUtsRLz6dhJ6D0yDo7MG5066YuncVrieYr5/g5dGpaFzeB78m95EeZkC544745sPA5CWbG9QrlWHIkT+9xpahRRDpwUuJzhiamQrlKsto73wcnQmOj9bgIBm6sq/wzEHrJjri2uX7R68s5mz9PP6TjojJ+gZs6/UzDdyiXTtl4eRM65j7QIfRIW3QNI5O8yNTYLKo0Lq0EzK0uvt5FyBj1cdg1YjYHpUCN4aGIavPmmBosLbv4dfGHYV/Yak4rP3W2Hcq4+g7KYCc5adgLWNVsLIjdPu0SJs+dYb4wa1wf+93gpKaxFz15yHrf3tOrXqUIT3VyXi+H4VxjzfBqMHtMWWNd4w3zt03C04rARbVjXA2OeaY8rgprBSipj3XZLB38ESWfp5/U86CEYv5krSZL9371707dsXfn5+EAQBmzZtkjKcKhk4MgfbYt2xY707Ui7aYfEkf6hvCggfkit1aCZl6fV+4Y0ryM60w8LpbXDhjAqZafY4cdADGddutXBEDIhIwbqvmuDQbi9cueiMT6a2hYenGmFPZUsauzGmDWuF33/0RMpFBySfd8SCiU3h3bAczduW6Mv8Z+pV/LzKG98v90PKRQekJdtj368eqCi3nLbCexFNEbfBHVcv2CHpnD0+GdsI3v4VaB58U+rQTMrSz2u6TdKztaSkBO3bt8fSpUulDKPKlNY6NA8uxfF9zvp1oijgxD5nBHUslTAy05JDvR/rmoOLZ50x5aO/EPvHHixZfwjhA9P0230a3oS7ZzlOHnbXrystViLxtAtaBxdIEbJJODhXtmSLCip7NFQeFWjVoQQFN6zxyfdnEXskHvO/O4c2nSz7rn6OLn//HfKtJI7EdORwXv+TVhSMXsyVpGP2zzzzDJ555hkpQ6gWF3ctrJRAfrbhny0vR4mAZmqJojI9OdTbx/8m+ryUho3fNsL6FY3Rok0h3pqUCE2FgJ1b/ODWoBwAkHfDxmC//Bs2+m3mThBE/GfaVZw95oSrFyp7NHwDKm9ZGzEmDV/HNELSOQf0GJiDmG8T8NYzwbh+xfLGtAVBxFuz0nDmiAOuJto/eAczJYfz+p/kPGZvVhP01Go11OrbH8LCwkIJoyFLIihEXDzrgtVLmgEAks67ILBZCZ59MQ07t1T9yVLmLGr2FTRuUYoJLwXp1wl/f7f9+p0X4n6ofDbB5XOOCHm8AL1ezMKqjxpJEapJRc9LQ2CrMvx3QDOpQyGqNWb1MyUmJgYqlUq/BAQE1On7F+ZaQasBXD01BuvdGmiQl21Wv5uqRQ71zsu2RWqSo8G61CRHePpWtmzzcipb9G4ehq14V49y/TZzNmrmFTzaPR+TXmmNnAxb/frcrMqHhqRcNGzhplyyh5efZfRo3Clq7jWEPl2Id194CDnp5v/v+m/kcF7/kw5GPs+eE/TqxpQpU1BQUKBfUlNT6/T9NRUKXPzLAR263B6vFAQRIV2KcS7eMi9VAeRR73MnVWjY2HCcsmFgCbKuV3ZTZ6TZIzfbBu1Db09csnfUoGW7QiT8parTWGuXiFEzr+DxXrmY/GprZF4z7JbPvGaLnAxr+Dc1nKjm36QMmWm2sBwiouZew+O9C/Duiw8hM9WS6nZvcjiv/0k0cia+aMbJ3qx+vtna2sLWVtqT8KcvG2DColRcOOWAxBMOeH5ENuwcdNixzv3BO5sxS6/3xv81wierj+Gl4cnYt8MbLdsW4pkX0rB4duu/SwjYtLYRBo9IxvWrDshMs8drUZdxI9sWB3eZ76N3o2ZfQbd+NzB7ZAvcLFbo5x+UFCn/voZewI9f+eLVsWlIPu+Ay+cc0XNgNvwfuom5Uc2lDb4WRc9LQ/fn8zBzWJPKv4Nn5aVnJUVWKC8zqzZRtVj6ef1PfOodVdmezW5QeWjx+sQMuHlqkHTWHu9FNEF+Ts2fkWwOLL3eF8+q8P74YAwdfQmv/CcZGWl2+GJ+S+z+1Vdf5oeVgbCz1+Kd6Qlwctbg7AlXTH87BBXl5jtj+7lXswAA89clGKz/ZGJT/P5j5Y+YTSt9YW0rYuR7KXB21SApwQHvvd4a6SmWMzmv79AbAICPf7pssP7jsQGI22CZiQ+w/POabhNEUbpbYxQXF+PSpUsAgA4dOmDBggXo3r073N3d0ajRgyf+FBYWQqVSoRv6Qynww2nprDzNtwVtDLHIsi9zux9dWZnUIVAd0IgV2I2fUVBQABcXlwfvUAO3csXzccNg7VjzuRgVJeXY+PRKk8ZqKpK27I8dO4bu3bvrX48fPx4AEBkZiVWrVkkUFRERWSJ240ukW7dukLBjgYiISBY4Zk9ERLJg7P3tzfnSOyZ7IiKSBTl341vuNSVEREQEgC17IiKSCTm37JnsiYhIFuSc7NmNT0REZOHYsiciIlmQc8ueyZ6IiGRBhHGXz5nzXWGY7ImISBbk3LLnmD0REZGFY8ueiIhkQc4teyZ7IiKSBTkne3bjExERWTi27ImISBbk3LJnsiciIlkQRQGiEQnbmH2lxm58IiIiC8eWPRERyQKfZ09ERGTh5Dxmz258IiIiC8eWPRERyYKcJ+gx2RMRkSzIuRufyZ6IiGRBzi17jtkTERFZOLbsyWz8eipO6hAk8ch7o6QOQRLuq49IHULd02mljsCiiUZ245tzy57JnoiIZEEEIIrG7W+u2I1PRERk4diyJyIiWdBBgMA76BEREVkuzsYnIiIii8WWPRERyYJOFCDwpjpERESWSxSNnI1vxtPx2Y1PRERk4diyJyIiWZDzBD0meyIikgUmeyIiIgsn5wl6HLMnIiKycGzZExGRLMh5Nj6TPRERyUJlsjdmzL4Wg6lj7MYnIiKycGzZExGRLHA2PhERkYUTYdwz6c24F5/d+ERERJaOLXsiIpIFduMTERFZOhn347Mbn4iI5OHvln1NF9SgZZ+WloZXX30VHh4esLe3R7t27XDs2LHbIYkipk+fDl9fX9jb26Nnz564ePGiwTFyc3MREREBFxcXuLq6Yvjw4SguLq5WHEz2REREJpCXl4fOnTvD2toav/32G86dO4dPPvkEbm5u+jLz58/H4sWLsXz5chw+fBiOjo4IDw9HWVmZvkxERATOnj2LuLg4bN26FXv37sXIkSOrFQu78YmISBbq+g56H374IQICArBy5Ur9uiZNmtxxPBGLFi3C1KlT0b9/fwDAmjVr4O3tjU2bNmHw4MFISEjAtm3bcPToUXTq1AkAsGTJEjz77LP4+OOP4efnV6VY2LInIiJZMKYL/87JfYWFhQaLWq2+5/tt3rwZnTp1wosvvggvLy906NABX331lX57cnIyMjIy0LNnT/06lUqF0NBQHDx4EABw8OBBuLq66hM9APTs2RMKhQKHDx+uct2Z7ImIiKohICAAKpVKv8TExNyzXFJSEpYtW4bmzZtj+/btGDVqFEaPHo3Vq1cDADIyMgAA3t7eBvt5e3vrt2VkZMDLy8tgu1KphLu7u75MVbAbvwb6Ds3BC6Oy4O6pQdI5e3w+tSESTzpIHZbJWVq9S4sVWD3fFwd+UyH/hhIPtbmJUXOuoWXITQBAXrYSK+b6IX6PM0oKrND2sWJEvX8NDZuW649x/YoNvprth7NHnFBRLqBj90JEvZ8GN0+NVNX6V4MePYtBoWfh61oEAEjKcseKPzriwIVGAIDnHzmH8OCLaOmXAye7CnSfMwzFZbYGx/jk1d/QwvcG3BxvoqjMFkcuNcSS7Y8hp8ixzutTU21Di/DiW5lo3u4mPHwqMHN4Uxzc7npHCRGvT0hH7yE5cFJpce6oExb/XwCuJ9tJFbLJWNp5/a9qOMnOYH8AqampcHFx0a+2tbW9Z3GdTodOnTph3rx5AIAOHTrgzJkzWL58OSIjI2seRw2wZV9NXfvlYeSM61i7wAdR4S2QdM4Oc2OToPKokDo0k7LEei/8bwCO73XCu0uuYvnO8+jYtQiTX26GnHRriCIw640mSL9qg5krk7B0RyK8/csx+eVmKCutPG3KShX4vyEPQRCAD7+/hAU/X4SmXIHpkU2g00lcufvIKnTEZ9tD8frngxD5+SAcS/LDxxHb0NQrFwBgZ63BwYuNsGrPw/c9xrEkP0xZ9zReWDQYk2J7wd+9EB8O2VFXVagVdg46JJ1zwGdTA+65/aW3M9F/WDaWTGmEMX1boqxUgXn/uwRr23r6D1tDlnhe/5tbY/bGLADg4uJisNwv2fv6+iIoKMhgXevWrZGSkgIA8PHxAQBkZmYalMnMzNRv8/HxQVZWlsF2jUaD3NxcfZmqkDTZx8TE4JFHHoGzszO8vLwwYMAAJCYmShnSAw0cmYNtse7Ysd4dKRftsHiSP9Q3BYQPyZU6NJOytHqrbwrY/6sr3pyajnaPlaBhk3K8NiEDfo3V2LrGA2lJtkiId8Q7H1S29AOaqfHOB9egLhPwx0ZXAMDZI47ITLXBfxeloEnrMjRpXYaJn17FxVMOOLnfSdoK3se+841x4EIgUm+4IuWGK5bFhaK03BptAyq/bL47EIzVezvgdKrXfY/x3YH2OJPqjYx8Z/yV4oPVezugbUAmrBTauqqG0Y79ocLqj/xwYJvrPbaKGDA8C98t9sHBHa5ITnDA/LGN4eFdgcfD8+s4UtOytPO6vuncufNdOe3ChQsIDAwEUDlZz8fHBzt37tRvLywsxOHDhxEWFgYACAsLQ35+PuLj4/Vldu3aBZ1Oh9DQ0CrHImmy37NnD6KionDo0CHExcWhoqICvXr1QklJiZRh3ZfSWofmwaU4vs9Zv04UBZzY54ygjqUSRmZallhvrVaATivA5h8tNVs7nb5LHoDBdoUCsLYRcfZoZSKvKBcAoXLdLda2IgQFcPZI/Uz2d1IIOjzd7hLsbSpwOsX7wTvcg4t9GXq3v4i/Unyg1VnVcoTS8GlUDg9vjcHnvbTICudPOqJ1x/r53VQTlnheP5BYC0s1jBs3DocOHcK8efNw6dIlxMbG4ssvv0RUVBQAQBAEjB07Fu+//z42b96M06dP4/XXX4efnx8GDBgAoLInoHfv3hgxYgSOHDmCP//8E9HR0Rg8eHCVZ+IDEo/Zb9u2zeD1qlWr4OXlhfj4eDz55JN3lVer1QazHgsLC00e451c3LWwUgL52YZ/trwcJQKa3Xs2piWwxHo7OOnQumMJYhf5oFHzK3D11GD3JjckxDvCr7EaAc3K4NWwHN/E+GLMh9dg56DDT196IifdBrmZlX+HVh1LYOegw4q5fhg2+ToAASvm+kKnFZCbVX+nwzzkfQPf/GcjbJRa3Cy3xsS14UjOdq/WMaLDD+Glx87A3kaDv1K8MX7NMyaKtu65e1Z2YefnWBusz89W6rdZAks8rx+krm+X+8gjj2Djxo2YMmUKZs+ejSZNmmDRokWIiIjQl3n33XdRUlKCkSNHIj8/H126dMG2bdtgZ3d7fsjatWsRHR2NHj16QKFQYNCgQVi8eHG1YqnSN9LmzZurfMB+/fpVK4A7FRQUAADc3e/9xRMTE4NZs2bV+PhEd3p3yVUsGN8IrzzcFgorEc3alaLbgDxc/MsBSmtg+opkLBjfCC8EtYPCSkSHJ4rwyFOF+nE7Vw8tpn5xBUum+OPnFQ0gKIDuA/LQrF0phHo8G+ZqjisiPnsRTnbl6NE2CTNf+AP/+apftRL+t/vaY/OxVvBxLcKIp+Ix88VdGLfmGQDme+9wIlN47rnn8Nxzz913uyAImD17NmbPnn3fMu7u7oiNjTUqjiol+1vdCQ8iCAK02pqN2+l0OowdOxadO3dG27Zt71lmypQpGD9+vP51YWEhAgLuPcHGFApzraDVAK7/mGnt1kCDvOz625IzlqXW269xOT7+6RLKShUoKVLAw1uDuf8JhG9gZaumefBNLPs9ESWFClRUCHD10GJ0n+ZoEXy7i7NjtyKsOpiAghtWsFICTiotBrdvA99G9bdlpNFa4VquCgBw/ronghpmYfDjpxHzc9cqH6Og1B4FpfZIueGKK9lu+GXS/9AuIBOnU6s+Yai+ys2ubNG7NqhAbtbt1r2rpwaXz9pLFVats9Tz+oHM+P72xqhS+0On01VpqWmiB4CoqCicOXMG69atu28ZW1vbu2ZB1iVNhQIX/3JAhy5F+nWCICKkSzHOxVvopSqw/HrbOejg4a1BUb4V4ve4ICzccHjI0UUHVw8t0pJscPGUw13bAUDloYWTSouT+52Qn6PEY73qdojJGIIgwkZZ83NXECq/Pa2NOEZ9kpFigxuZSoPPu4OTFq1CSpAQbz6XFz6IpZ/X91JbN9UxR0b9fCsrKzMYV6ip6Oho/f1+/f39jT6eKf30ZQNMWJSKC6cckHjCAc+PyIadgw471lVvzNPcWGK9j+12higCAQ+pkZZsg6/nNERAszL0evkGAGDvFhVUHlp4NSxHcoIdlk/3R1jvAnTsdvvLcfs6dzRqXgaVhwYJ8Y5YNr0hnh+ZXW/HPKN6HcaBCwHIyHeCg20Fere/hI5NruOdVX0AAB5OpfBwLkWAR+WPlWbeuSgtt0ZGvhMKb9qhjX8mgvyzceqqDwpv2sLfvRBv9TyC1BsuOJ1iPq16Owct/Brf/jfyCVCjaVApivKVyL5ug00rvDBkdAbSkm2RkWqLyAnXcSPTGgcMrsU3f5Z4Xv8rGT/1rtrJXqvVYt68eVi+fDkyMzNx4cIFNG3aFNOmTUPjxo0xfPjwKh9LFEW888472LhxI3bv3m1wz+D6as9mN6g8tHh9YgbcPDVIOmuP9yKa3DWZx9JYYr1LCq2wMsYXOenWcHbVovOz+Rg2OR3Kv6uUm2mNL2Y2RH6OEu5eGvR8MRevjDW8HvbaZVusjPFFUb4VvAPKMWR0JgaOzJagNlXj5ngTM1/YhQbOpSgus8GlDA+8s6oPjlyuHA4b+OhZjOxx+xKfr0b+DACY9UM3bD3RCmUVSnQPSsLIHkdhb61BTpEDDl4MwDe7H0aF1nxm47doX4qPvr/9ZLG3ZqYBAHZscMcn4xtjw+fesHPQYcyHKXBy0eLsUSe892ozVKjr8WSMGrDE85ruTRDF6t3af/bs2Vi9ejVmz56NESNG4MyZM2jatCnWr1+PRYsW6e/nWxVvv/02YmNj8fPPP6Nly5b69SqVCvb2Dx4bKywshEqlQjf0h1Lgh9PSbb9+UuoQJPHIe6OkDkES7quPSB1C3dNZxlBIdWjECuzGzygoKDDZ0OytXBGwfCYU9jXvjdbdLEPqWzNNGqupVPtn6po1a/Dll18iIiICVla3f8m3b98e58+fr9axli1bhoKCAnTr1g2+vr76Zf369dUNi4iI6N/V8XX29Um1u/HT0tLQrFmzu9brdDpUVFTvGtRqdioQERFRDVS7ZR8UFIR9+/bdtf6HH35Ahw4daiUoIiKiWseWfdVNnz4dkZGRSEtLg06nw08//YTExESsWbMGW7duNUWMRERExqulp96Zo2q37Pv3748tW7bg999/h6OjI6ZPn46EhARs2bIFTz/9tCliJCIiIiPU6Dr7J554AnFxcbUdCxERkcnc+Zjamu5vrmp8U51jx44hISEBQOU4fseOHWstKCIiolrHm+pU3bVr1zBkyBD8+eefcHV1BQDk5+fj8ccfx7p16+r9HfCIiIjkptpj9m+++SYqKiqQkJCA3Nxc5ObmIiEhATqdDm+++aYpYiQiIjLerQl6xixmqtot+z179uDAgQMGd7xr2bIllixZgieeeKJWgyMiIqotgli5GLO/uap2sg8ICLjnzXO0Wi38/PxqJSgiIqJaJ+Mx+2p343/00Ud45513cOzYMf26Y8eOYcyYMfj4449rNTgiIiIyXpVa9m5ubhCE22MVJSUlCA0NhVJZubtGo4FSqcQbb7yBAQMGmCRQIiIio8j4pjpVSvaLFi0ycRhEREQmJuNu/Col+8jISFPHQURERCZS45vqAEBZWRnKy8sN1pnbM36JiEgmZNyyr/YEvZKSEkRHR8PLywuOjo5wc3MzWIiIiOolGT/1rtrJ/t1338WuXbuwbNky2Nra4uuvv8asWbPg5+eHNWvWmCJGIiIiMkK1u/G3bNmCNWvWoFu3bhg2bBieeOIJNGvWDIGBgVi7di0iIiJMEScREZFxZDwbv9ot+9zcXDRt2hRA5fh8bm4uAKBLly7Yu3dv7UZHRERUS27dQc+YxVxVO9k3bdoUycnJAIBWrVphw4YNACpb/LcejENERET1R7WT/bBhw3Dq1CkAwOTJk7F06VLY2dlh3LhxmDhxYq0HSEREVCtkPEGv2mP248aN0/9/z549cf78ecTHx6NZs2YIDg6u1eCIiIjIeEZdZw8AgYGBCAwMrI1YiIiITEaAkU+9q7VI6l6Vkv3ixYurfMDRo0fXOBgiIiKqfVVK9gsXLqzSwQRBYLInk2m36G2pQ5BE17fjpQ5BEsnbPKUOoc5p0jOkDsGyyfjSuyol+1uz74mIiMwWb5dLRERElsroCXpERERmQcYteyZ7IiKSBWPvgierO+gRERGReWHLnoiI5EHG3fg1atnv27cPr776KsLCwpCWlgYA+Pbbb7F///5aDY6IiKjWyPh2udVO9j/++CPCw8Nhb2+PEydOQK1WAwAKCgowb968Wg+QiIiIjFPtZP/+++9j+fLl+Oqrr2Btba1f37lzZxw/frxWgyMiIqotcn7EbbXH7BMTE/Hkk0/etV6lUiE/P782YiIiIqp9Mr6DXrVb9j4+Prh06dJd6/fv34+mTZvWSlBERES1jmP2VTdixAiMGTMGhw8fhiAIuH79OtauXYsJEyZg1KhRpoiRiIiIjFDtbvzJkydDp9OhR48eKC0txZNPPglbW1tMmDAB77zzjiliJCIiMpqcb6pT7WQvCALee+89TJw4EZcuXUJxcTGCgoLg5ORkiviIiIhqh4yvs6/xTXVsbGwQFBRUm7EQERGRCVQ72Xfv3h2CcP8Zibt27TIqICIiIpMw9vI5ObXsQ0JCDF5XVFTg5MmTOHPmDCIjI2srLiIiotrFbvyqW7hw4T3Xz5w5E8XFxUYHRERERLWr1p569+qrr+Kbb76prcMRERHVLhlfZ19rT707ePAg7OzsautwREREtYqX3lXDwIEDDV6Looj09HQcO3YM06ZNq7XAiIiIqHZUO9mrVCqD1wqFAi1btsTs2bPRq1evWguMiIiIake1kr1Wq8WwYcPQrl07uLm5mSomIiKi2ifj2fjVmqBnZWWFXr168el2RERkduT8iNtqz8Zv27YtkpKSTBELERERmUC1x+zff/99TJgwAXPmzEHHjh3h6OhosN3FxaXWgquv+g7NwQujsuDuqUHSOXt8PrUhEk86SB2WyVlSvV8KPoOX252Fn0sRAOByrjuWH+6I/VcCAQD+qgJMeOIgOvilw8ZKiz+vNkLM7i64UXq7voGu+fjvEwcR4pcBa4UWF3I88NnBR3H0WkNJ6lQVyf3U0KTfvV71ggJek6wBADf/0uHGMg3KzogQrACbFgIaLraGwq7yzpll53XIWaKB+pwIWAFO3RXwHKeEwsF8nvX9zZY98PYru2v91g0BWPZhEKL/7yxCQm/AvYEaZTetkHDKFSuXtMC1K5b3DBBLOq+rxIxb58aocst+9uzZKCkpwbPPPotTp06hX79+8Pf3h5ubG9zc3ODq6lrtcfxly5YhODgYLi4ucHFxQVhYGH777bdqV6Iude2Xh5EzrmPtAh9EhbdA0jk7zI1NgsqjQurQTMrS6p1Z5IRFfz6Gl797AYO/ewGHUxticd9teMg9F/bKCnz5/FaIAN78sR9e3/A8rK20WNLvNwh3fFN81v9XWCl0ePPHfnj5uxcqk33/X+HhUCpdxR4gYLUNmvx2e2n4WWWCd+ppBaAy0V8fXQGHUAUCVlkjYJU1XF+00n9TaLJFpEVVwCZAQMBKazT81BrlSSIyZ2mkqlKNjH0tDK/26qZf3hvVCQCw/3cfAMClBBcsnNkWb73QBdOiO0EQgDlL46FQWFamsLTz+oF4nf2DzZo1C2+99Rb++OOPWntzf39/fPDBB2jevDlEUcTq1avRv39/nDhxAm3atKm196lNA0fmYFusO3asdwcALJ7kj0d7FCJ8SC42fOYtcXSmY2n13pPc2OD1kgOheDn4LIJ9M+HlVAI/lyK8GPsiSsptAADvbX8Kf476BqEBaTiU6g9Xu5to7FaAGXHdcCHHAwCwcP9jGNz+LJp75Br0ANQnSjfD1nfeai2s/QH7hyvX5yzUwPVlK7gPvf3VYNP4dvmSfToISsDzXSUEReU+XlOUSBlSgfJUETYB5tG6L8y3MXj9wtAkXE+1x+n4ygbLto0B+m1Z6fZY83lzLF1/AF5+N5FxrX7+29aEpZ3XdH9VTvaiWPmTpmvXrrX25n379jV4PXfuXCxbtgyHDh2ql8leaa1D8+BSrPvMS79OFAWc2OeMoI71tzVnLEuvt0LQoVfzy7BXVuBUujcCVIUQAZRrrfRl1FoldKKADg3TcSjVH/lldkjOdUXf1heQkOWJcq0VXmx3DjdK7HEuy1O6ylSDWCGi8Dct3CKsIAgCNLkiys6IcO4tIPWNclSkibAJFODxthL2IYq/9wEEJfSJHgAE27+790/qYBNgdc/3qs+USh26P5uOTf9rDODuHyu2dho83S8NGdfskZNhOTcOs/Tz+l54U50q+ren3RlLq9Xi+++/R0lJCcLCwu5ZRq1WQ61W618XFhaaLJ57cXHXwkoJ5Gcb/tnycpQIaKa+z17mz1Lr3dzjBv738k+wUWpRWmGNsVt7IynXHXk37XGzwhrjuhzE4j9DIQAY2+UQlAoRno63vgQFjPipLz7tuw2Hor6GThSQW2qPtzb1QaHaVspqVVnxbh10xYDLc5UJuiKt8pvsxlcaNBithG1LAUW/6JD2dgUarbOGTSMF7DsJyF4I5H2rgetgK+huAjc+q+zC1+SY5zfhY92z4OSkwe9b/AzW93kxBcNGX4C9gxapVxzxXlQnaDS1dodxyVnqef2vZHzpXbWSfYsWLR6Y8HNzc6sVwOnTpxEWFoaysjI4OTlh48aNCAoKumfZmJgYzJo1q1rHJ7qf5DxXvLD2JTjbluPp5pfxfq9dGPZDfyTluuO/v/TCtKf2IiLkNHSigN8Sm+NcZgPo9Ce7iPe670NuqT0iNwyAWqPEwLYJ+Kzfbxj83SDklDr+21vXC4WbtXAMU0Dp+fc5rav8j+p5K6j6Vf4AsGupQOlRHQo369AgWgHbhxTwnqlEzkINcpZqISgA1ctWsHJHLT5po2716n8Nxw40QG6OYav9j998ceKQB9waqDHotSuY8sEpTHjjUVSUm1/vBVG1kv2sWbPuuoOesVq2bImTJ0+ioKAAP/zwAyIjI7Fnz557JvwpU6Zg/Pjx+teFhYUICAi4q5ypFOZaQasBXD0NJyO5NdAgL7vWHjNQ71hqvTU6K6QWVH6ez2V5oq13Fl7tcBqzd3bFwZQAPLsqAq52N6EVFShS2+KPEatw7ULl1SahAWl4sslVdF7+hn5cf+4fnghrdA39gxKx4tjDktWrKirSRZQeEeE7/3biUjaoTPo2TQx/0Ns0FqDJuN2kceltBZfeVtDcEKGwByAA+bFaWDc0j/H6O3n63ETIozcwb2KHu7aVFlujtNga11MdkXjaFet378Lj3bOwZ7uvBJHWPks9r/+NnLvxq/VbfPDgwYiMjPzXpbpsbGzQrFkzdOzYETExMWjfvj0+/fTTe5a1tbXVz9y/tdQlTYUCF/9yQIcuRfp1giAipEsxzsVbzqSdf5JLvQVBhI2V1mBdfpk9itS2eNT/GtwdbmJ3UmMAgJ2y8gtSJxomOJ1YeZz6rnCLFlZugGPn218BSj/AyhOouGoYf0WKCKXv3Ylc6SFA4SCgKE4HwQZwCDW/pv3T/dJQkGeDI/sb/HtBAYAgwtpGVydx1QW5nNcGJJyN/8EHH0AQBIwdO1a/rqysDFFRUfDw8ICTkxMGDRqEzMxMg/1SUlLQp08fODg4wMvLCxMnToRGU/2rX6r8882U4/V30ul0BuPy9c1PXzbAhEWpuHDKAYknHPD8iGzYOeiwY5271KGZlKXVe0znQ9h/pRHSi5zgaF2BZ1tdxCP+1/HWxucAAAOCziMp1xW5N+0R4puJSV3349vj7XElr3K29ql0bxSqbTG3104sP9wJao0Sg9qeg7+qCHuTA6Ws2gOJOhGFW7Rw6WMFQXnHRDtBgNurVsj9UgubFgJsWyhQtFWL8qsifD683QOQv0ELu2ABCnug9LCInMUaNIi2gpWzebXsBUHE0/3SsHNrQ+i0t3+o+DQsxRO9MnDioAcK8m3QwKsMLw5NRnmZFY4+6EeBmbG087q+Onr0KL744gsEBwcbrB83bhx++eUXfP/991CpVIiOjsbAgQPx559/Aqicy9anTx/4+PjgwIEDSE9Px+uvvw5ra2vMmzevWjFUezZ+bZoyZQqeeeYZNGrUCEVFRYiNjcXu3buxffv2Wn+v2rJnsxtUHlq8PjEDbp4aJJ21x3sRTZCfYy11aCZlafV2t7+JueG74OlQgqJyG1zM8cBbG5/DwZTKYaHGbvkY0/kQVHZqpBU646sjHbHmxO0TNb/MHm9t7IPRnY9gxaDNUCp0uJzrjtFbeuNCTv1OCKVHRGgyAJd+d7fE3V5RQiwHchZooC0EbJsLaPiZNWz8byfysrM63PhSB7EUsG4swOv/lHB51vzGsUNCb8DLtww7fja8CVK5WoE2IXnoP+QqnFwqkH/DFmdOuGHCG6EoyDOPyZdVZWnn9QNJMEGvuLgYERER+Oqrr/D+++/r1xcUFGDFihWIjY3FU089BQBYuXIlWrdujUOHDuGxxx7Djh07cO7cOfz+++/w9vZGSEgI5syZg0mTJmHmzJmwsbG539veRRBNkcWraPjw4di5cyfS09OhUqkQHByMSZMm4emnn67S/oWFhVCpVOiG/lAKFvrhJL3r7z4udQiS6PpivNQhSCK5n/wetqVJz5A6hDqnESuwGz+joKDAZEOzt3JFy3HzYGVb88snteoyJC78P6SmphrEamtrC1vbe/8QjIyMhLu7OxYuXIhu3bohJCQEixYtwq5du9CjRw/k5eXB1dVVXz4wMBBjx47FuHHjMH36dGzevBknT57Ub09OTkbTpk1x/PhxdOhw91yT+5F0FsaKFSukfHsiIpKTWmrZ/3Ni+IwZMzBz5sy7iq9btw7Hjx/H0aNH79qWkZEBGxsbg0QPAN7e3sjIyNCX8fb2vmv7rW3VYZlTLomIiEzkXi37e5UZM2YM4uLiYGcn/c2YzG/6LBERUU3U0mz8f14Vdq9kHx8fj6ysLDz88MNQKpVQKpXYs2cPFi9eDKVSCW9vb5SXl9/1yPjMzEz4+FQ+o8HHx+eu2fm3Xt8qU1VM9kREJAt1+Tz7Hj164PTp0zh58qR+6dSpEyIiIvT/b21tjZ07d+r3SUxMREpKiv4usmFhYTh9+jSysrL0ZeLi4uDi4nLfm8/dD7vxiYiIapmzszPatm1rsM7R0REeHh769cOHD8f48ePh7u4OFxcXvPPOOwgLC8Njjz0GAOjVqxeCgoLw2muvYf78+cjIyMDUqVMRFRV13wmB98NkT0RE8lDP7o2/cOFCKBQKDBo0CGq1GuHh4fj888/1262srLB161aMGjUKYWFhcHR0RGRkJGbPnl3t92KyJyIiWZD6drm7d+82eG1nZ4elS5di6dKl990nMDAQv/76q3FvDI7ZExERWTy27ImISB7qWTd+XWKyJyIieZBxsmc3PhERkYVjy56IiGRB+HsxZn9zxWRPRETyIONufCZ7IiKSBakvvZMSx+yJiIgsHFv2REQkD+zGJyIikgEzTtjGYDc+ERGRhWPLnoiIZEHOE/SY7ImISB5kPGbPbnwiIiILx5Y9ERHJArvxiYiILB278YmIiMhSsWVPRESywG58IjMQsOK81CFI4kjmw1KHIIkGLtlSh1D30qUOwMLJuBufyZ6IiORBxsmeY/ZEREQWji17IiKSBY7ZExERWTp24xMREZGlYsueiIhkQRBFCGLNm+fG7Cs1JnsiIpIHduMTERGRpWLLnoiIZIGz8YmIiCwdu/GJiIjIUrFlT0REssBufCIiIksn4258JnsiIpIFObfsOWZPRERk4diyJyIieWA3PhERkeUz5654Y7Abn4iIyMKxZU9ERPIgipWLMfubKSZ7IiKSBc7GJyIiIovFlj0REckDZ+MTERFZNkFXuRizv7liNz4REZGFY8u+BvoOzcELo7Lg7qlB0jl7fD61IRJPOkgdlslZcr0jRiUj4u0rButSkx3wn36hAIDo6Yno8Fgu3D3LUVZqhXOnVFi5sCmuJTtKEG3NDQo9i4GhZ+HrVgQASM5yx9c7O+LghUYAABulBmOePYhe7S/B2kqLQxcDMP/nJ5BbbPjv3Ofh83ily19o1KAAJWpr7Dz9ED7a/ESd16eq2gZnY9DLF9CsRT48GpRhztTHcPDPhvrtjz+Rhmf7JqFZi3y4qMoR/WYPJF121W/38i7BqnXb7nnseTNDsX+Pv6mrYDKWfF7fhd34VFVd++Vh5IzrWDLZH+ePO+D5EdmYG5uE4U+0RMENa6nDMxk51PvKRUe8N6K9/rVWK+j//9I5Z+z+xRtZ6bZwVmkQMSoZ739xCm/0DoNOJ9zrcPVSZoEjlm4PRWqOCoIA9Hk4ER+/tg2vLXkBSVnuGNfnADq3SsGUtb1QXGaDif3348OI7RjxxfP6Y7zS5RRe6XIKS34Lw5lUL9jbaPQ/HuorOzstki+7YsdvjTFtzqF7bNfg7JkG2LfbH2MmHr9re062AyIG9jFY17tvMga9fAHHDvuYLG5Tk8N5fSfOxq8HPvjgAwiCgLFjx0odyr8aODIH22LdsWO9O1Iu2mHxJH+obwoIH5IrdWgmJYd6a7UC8m7Y6pfCfBv9tm0/+OFMvCuyrtvjcoIz1nzWFF6+anj5lUkYcfXtP98YBxIDkXrDFSk5rli2IxSl5dZo2ygTjrZq9Ot0Hot+CcOxpIY4f90Ts3/ohvaNM9E2IBMA4GynxltPH8Ws75/C9lPNkZarwqUMD+xLaCxtxR7g2BEfrPmmDQ7ub3jP7bviAvHdmtY4Ee91z+06nYC8PDuD5fEuadi32x9lZebbZpLDeW3g1nX2xixmql4k+6NHj+KLL75AcHCw1KH8K6W1Ds2DS3F8n7N+nSgKOLHPGUEdSyWMzLTkUu+GjUrx7c4/seK3g5j4wTl4+tw7kdvaa/H0gHSkX7NDToZtHUdZexSCDk8HX4K9TQVOp3ijdcMcWCt1OHLpdpf01Ww3pOc5oV2jDABAaPNUCIIIT5cSrB+3Dlsmf4t5Q3bAS1UsVTUk0axFHh5qXoAdvzaWOpQak8t5TZUk/0laXFyMiIgIfPXVV3j//ff/taxarYZarda/LiwsNHV4BlzctbBSAvnZhn+2vBwlApqp77OX+ZNDvRNPu2DBtNa4dsUB7g3UeGXUFXy0+jhGPf8obpZW1rvPy2l4Y/xl2DtokZrsgPdGhECjqRe/l6vlIe8bWDFqI2yUWtwst8a7/wtHcpY7WvheRLlGgeIywx8wucX28HC+CQDwcy+CQhAxtNsJLNjaGcVlNnir1xF89sZWvLL4RWi0VlJUqc71evYKUq44I+Gsh9Sh1Jgczut/Yje+hKKiotCnTx/07NnzgWVjYmKgUqn0S0BAQB1ESHJwbL8H9u/wwpULTjh+wAMz3g6Go7MGT4Rn6cv88Ys33nmxE94d2gFpV+wx5ZMzsLbRShh1zVzNccWrS17EG58PxI+H22DGC3+giVfVum0VgghrpQ6fbO2MQxcDcCbVG1PX9URAgwJ0anrdxJHXDzY2WnTrkYrtZtyqly2xFhYzJWnLft26dTh+/DiOHj1apfJTpkzB+PHj9a8LCwvrNOEX5lpBqwFcPTUG690aaJCXLXknicnIsd4lRdZIu+oAv0Y39etKi5UoLVbieooDzp9ywYY/9+HxHjnY85u3hJFWn0ZrhWs3VACA89c9EeSfhZcfP43f/2oGG6UOTnZqg9a9u9NN3CiyBwDkFFXO0k7OdNNvzy+xR36JHbxd6/ckvdrSpes12NpqsHNHoNShGEWO57WcSdayT01NxZgxY7B27VrY2dlVaR9bW1u4uLgYLHVJU6HAxb8c0KHL7S81QRAR0qUY5+It9FIVyLPedvYa+AbcRG72fcbkhcrF2saM77LxN4UgwkapRUJaA1RoFHjkoTT9tkYN8uHrVozTKZUzzv+6WvnfQM98fRkX+zK4OpYhI98ZctDr2Ss4fMAPhQXmO18DkOd5fasb35jFXEn28y0+Ph5ZWVl4+OGH9eu0Wi327t2Lzz77DGq1GlZW9W/876cvG2DColRcOOWAxBOVl6rYOeiwY5271KGZlKXXe/h/L+HwHg9kXbeDh2c5Xo1Khk4rYPdvXvDxv4knw7Nw/KA7CnKt0cBbjReHX0W5WoGj+8xrzPbt8MM4mBiAjHwnONhWIDzkEh5uch2jV/ZBidoWm4+1wtg+B1B40xYlZTaY0G8//rrqjTOplb0XKTmu2HO2McY/9yfmbeyKErUNosIP42q2K45d9pO4dvdnZ6eBX8Pbkwi9fUvR9KF8FBXZIDvLAU7O5fDyKoV7g8qeHP9GlQkwL7dy5v0tvn7FaBucgxmTO9dtBUzE0s/ru/Cpd3WvR48eOH36tMG6YcOGoVWrVpg0aVK9TPQAsGezG1QeWrw+MQNunhoknbXHexFNkJ9jedek3snS693AW41JH56Di2sFCvJscPa4CuMiOqIwzwZKpRptOuaj/2upcHLRIP+GDc7Eu+K/r3VEQa7Ngw9ej7g73sSMl3ahgXMpistscCnDA6NX9sGRS5XDYQt/eRw6UcAHETtgo9Ti0IXKm+rcaeb3T2FcnwNYOPRXiKKA40l+GL2yD7S6+nnOAkDzlnn4cNFe/euRUX8BAOK2BWLhh53w2OPXMX5yvH775OlHAABrV7XG2tVB+vW9nr2CnGx7HD9mXkM392Pp5zXdJohi/fmp0q1bN4SEhGDRokVVKl9YWAiVSoVu6A+lwA+npbPysNDWxgPkPNdS6hAk0eBQttQh1Dlt4iWpQ6hzGrECu/EzCgoKTDY0eytXhD0zG0rrqg0b34umogwHf5tu0lhNhbMwiIhIHni73Pph9+7dUodARERkcepVsiciIjIVOd9Uh8meiIjkQSdWLsbsb6aY7ImISB5kPGYv+e1yiYiIyLTYsiciIlkQYOSYfa1FUveY7ImISB5kfAc9duMTERFZOCZ7IiKShbp+EE5MTAweeeQRODs7w8vLCwMGDEBiYqJBmbKyMkRFRcHDwwNOTk4YNGgQMjMzDcqkpKSgT58+cHBwgJeXFyZOnAiNxvBphQ/CZE9ERPJQx8+z37NnD6KionDo0CHExcWhoqICvXr1QklJib7MuHHjsGXLFnz//ffYs2cPrl+/joEDB+q3a7Va9OnTB+Xl5Thw4ABWr16NVatWYfr06dWKhWP2REREJrBt2zaD16tWrYKXlxfi4+Px5JNPoqCgACtWrEBsbCyeeuopAMDKlSvRunVrHDp0CI899hh27NiBc+fO4ffff4e3tzdCQkIwZ84cTJo0CTNnzoSNTdUexsWWPRERyYIgikYvQOWDde5c1Gp1ld6/oKAAAODuXvlQr/j4eFRUVKBnz576Mq1atUKjRo1w8OBBAMDBgwfRrl07eHvfftJieHg4CgsLcfbs2SrXncmeiIjkQVcLC4CAgACoVCr9EhMT8+C31ukwduxYdO7cGW3btgUAZGRkwMbGBq6urgZlvb29kZGRoS9zZ6K/tf3WtqpiNz4REVE1pKamGjzi1tbW9oH7REVF4cyZM9i/f78pQ7svJnsiIpKFO7via7o/ALi4uFTrefbR0dHYunUr9u7dC39/f/16Hx8flJeXIz8/36B1n5mZCR8fH32ZI0eOGBzv1mz9W2Wqgt34REQkD3U8G18URURHR2Pjxo3YtWsXmjRpYrC9Y8eOsLa2xs6dO/XrEhMTkZKSgrCwMABAWFgYTp8+jaysLH2ZuLg4uLi4ICgoqMqxsGVPRETyUMd30IuKikJsbCx+/vlnODs768fYVSoV7O3toVKpMHz4cIwfPx7u7u5wcXHBO++8g7CwMDz22GMAgF69eiEoKAivvfYa5s+fj4yMDEydOhVRUVFVGj64hcmeiIjIBJYtWwYA6Natm8H6lStXYujQoQCAhQsXQqFQYNCgQVCr1QgPD8fnn3+uL2tlZYWtW7di1KhRCAsLg6OjIyIjIzF79uxqxcJkT0REslCTu+D9c//qEKvQE2BnZ4elS5di6dKl9y0TGBiIX3/9tXpv/g9M9kREJA98EA4RERFZKrbsiYhIFgRd5WLM/uaKyZ6IiOSB3fhERERkqdiyJ7OhvZErdQiS8PjpjNQhSEJXVrWHixBVWQ1ujHPX/maKyZ6IiGShtm6Xa47YjU9ERGTh2LInIiJ5kPEEPSZ7IiKSBxH6Z9LXeH8zxWRPRESywDF7IiIislhs2RMRkTyIMHLMvtYiqXNM9kREJA8ynqDHbnwiIiILx5Y9ERHJgw6AYOT+ZorJnoiIZIGz8YmIiMhisWVPRETyIOMJekz2REQkDzJO9uzGJyIisnBs2RMRkTzIuGXPZE9ERPLAS++IiIgsGy+9IyIiIovFlj0REckDx+yJiIgsnE4EBCMSts58kz278YmIiCwcW/ZERCQP7MYnIiKydEYme5hvsmc3PhERkYVjy74G+g7NwQujsuDuqUHSOXt8PrUhEk86SB2Wycmt3s+9noM+r9+Ad0A5AOBqoh3WLvTGsT9cJI6s9vQZko4+Q9Lh3VANALh60QGxnwfg2F53fZlWIYWIHHcVrYKLoNMJuJzgiKnD26BcbSVV2EZr+2gRXvhPOpq3K4WHdwVmjWiGgzvcDMoENLuJ4ZOvoV1oEayUIlIu2mHOW82Qfd1WoqhNQ1bntYy78SVt2c+cOROCIBgsrVq1kjKkB+raLw8jZ1zH2gU+iApvgaRzdpgbmwSVR4XUoZmUHOudnW6Nb+b5Irp3C7zzTAuc+tMJM1deQWCLMqlDqzU5GTZY+XFjvDMwBKMHheDUIRWmL01Ao2YlACoT/ftfn8Xx/a4Y82J7jH6hPbas9YWoM+Y2ZNKzc9AiOcEBS6cF3nO7b6MyfPJDAlIv2+HdwS0xKrwNYhf7oVxtWZ2hsjuvdaLxi5mSvGXfpk0b/P777/rXSqXkIf2rgSNzsC3WHTvWV7Z8Fk/yx6M9ChE+JBcbPvOWODrTkWO9D8epDF6v+tAXz71+A606luDqBTuJoqpdh//wMHi9elFj9BmSgVYhRUi55Ij/TEnGz9/64fuvAvRl0pLNv9V3bLcrju12ve/2yIlpOPqHK1bE3K53eopl/JvfSY7ntVxJ/jNVqVTCx8dHvzRo0EDqkO5Laa1D8+BSHN/nrF8nigJO7HNGUMdSCSMzLbnW+04KhYiu/fNg66BDwjFHqcMxCYVCRNdns2HnoMX5Ey5QuZejVUgRCm5Y45PvTiH2z8OY/+1faNOxQOpQTUoQRDz6VD7Sku0wd00i1sWfwKJN5xDWK0/q0GqVLM9rUWf8YqYkT/YXL16En58fmjZtioiICKSkpNy3rFqtRmFhocFSl1zctbBSAvnZhr0PeTlKuHlq6jSWuiTXegNA41Y3seniaWy98hdGf3ANs4c3RspFy2rhNW5Rgp+OH8Dm038ietYlzIlqjZTLDvANqByuiIhOwbbvfTDtzTa4dM4JMavOwC/wpsRRm45rAw0cnHR4aVQ6ju1R4f9ea4kD290w7YtLaBdat985piTL8/rWmL0xi5mSNNmHhoZi1apV2LZtG5YtW4bk5GQ88cQTKCoqumf5mJgYqFQq/RIQEHDPckS15dplW7z9dAuM7tMcW9c0wIRPU9CoueWM2QPAtWR7RA3ogLEvheCX73zx3w8voNFDpRD+/nb4db0P4n7yxuUEJ3wZ0xTXku3Ra1CmtEGbkPD3HdYOxrli4wofJJ1zwIZlvjiy0xV9IrIljo6MIuMxe0mT/TPPPIMXX3wRwcHBCA8Px6+//or8/Hxs2LDhnuWnTJmCgoIC/ZKamlqn8RbmWkGrAVz/8avXrYEGedn1e66BMeRabwDQVChw/YotLp12wMoYXySfs8eANy3rC19ToUB6ij0unXXCqgWNkXTeEf1fv47cbBsAQMplwzH6lMsO8PJTSxFqnSjMU0JTISDlor3B+pRLdvBsWC5RVLVPzue1HEnejX8nV1dXtGjRApcuXbrndltbW7i4uBgsdUlTocDFvxzQocvtngdBEBHSpRjn4s1/0tL9yLXe9yIIgLWN+f66rwpBAVjb6JB5zRY5mTbwb2LYZe/f+CYy0yzr8rM7aSoUuPCXA/ybGvbgNGxShqw0G4miqn2yPK/ZjV8/FBcX4/Lly/D19ZU6lPv66csGeOaVXPR8MRcBzcrwzgfXYOegw4517g/e2YzJsd7DpqSjbWgxvP3L0bjVTQybko7gx4vxx0a3B+9sJoaOv4K2nQrg1bAMjVuUYOj4Kwh+tAB/bPEEIODHFQ3R/7Xr6BKeA99GN/HamKvwb3oTO34w75nadg5aNA0qRdOgyoloPgFqNA0qheffPRY/fOGLJ5/LRe/B2fANLEPfyEw81jMfW9d4SRl2rZPdeS3CyGQvdQVqTtK+mgkTJqBv374IDAzE9evXMWPGDFhZWWHIkCFShvWv9mx2g8pDi9cnZsDNU4Oks/Z4L6IJ8nOspQ7NpORYb9cGGkxcnAJ3Lw1Ki6yQnGCH915piuN7nR+8s5lw9ajAhA8vwN2rHCVFSiQnOmDq8DY4caDyB82m1Q1hbaPDyClJcFZpkHTeEe+90QbpqfYPOHL91iK4BPPXJ+pf/2d65ZBg3Pce+GRCUxzY7oYl7wXi5bfTMWrWVVy7XHlDnbPHLOffHpDneS1XgihK1y8xePBg7N27Fzdu3ICnpye6dOmCuXPn4qGHHqrS/oWFhVCpVOiG/lAK/HCSZVI4W1aCqSqxzHLnBdyPWGE5cwKqSiNWYDd+RkFBgcmGZm/lip4+I6FU1HwoRqMrx+8ZX5o0VlORtGW/bt06Kd+eiIjkRKcDYMS18jpeZ09ERET1FK+vICIieZDxg3CY7ImISB5knOzZjU9ERGTh2LInIiJ50Ikw6mJ5M75dLpM9ERHJgijqIBrx5Dpj9pUakz0REcmDaOTDbDhmT0RERPUVW/ZERCQPopFj9mbcsmeyJyIiedDpAMGIcXczHrNnNz4REZGFY8ueiIjkgd34RERElk3U6SAa0Y1vzpfesRufiIjIwrFlT0RE8sBufCIiIgunEwFBnsme3fhEREQWji17IiKSB1EEYMx19ubbsmeyJyIiWRB1IkQjuvFFJnsiIqJ6TtTBuJY9L70jIiKie1i6dCkaN24MOzs7hIaG4siRI3UeA5M9ERHJgqgTjV6qa/369Rg/fjxmzJiB48ePo3379ggPD0dWVpYJanh/TPZERCQPos74pZoWLFiAESNGYNiwYQgKCsLy5cvh4OCAb775xgQVvD+zHrO/NVlCgwqj7pNAVJ8pxHKpQ5CEKFZIHUKdk2OdNaisc11MfjM2V9yKtbCw0GC9ra0tbG1t7ypfXl6O+Ph4TJkyRb9OoVCgZ8+eOHjwYM0DqQGzTvZFRUUAgP34VeJIiEyoSOoAiEyvqKgIKpXKJMe2sbGBj48P9mcYnyucnJwQEBBgsG7GjBmYOXPmXWVzcnKg1Wrh7e1tsN7b2xvnz583OpbqMOtk7+fnh9TUVDg7O0MQhDp978LCQgQEBCA1NRUuLi51+t5SkmO95VhnQJ71lmOdAWnrLYoiioqK4OfnZ7L3sLOzQ3JyMsrLje8lE0Xxrnxzr1Z9fWPWyV6hUMDf31/SGFxcXGT1pXCLHOstxzoD8qy3HOsMSFdvU7Xo72RnZwc7OzuTv8+dGjRoACsrK2RmZhqsz8zMhI+PT53Gwgl6REREJmBjY4OOHTti586d+nU6nQ47d+5EWFhYncZi1i17IiKi+mz8+PGIjIxEp06d8Oijj2LRokUoKSnBsGHD6jQOJvsasrW1xYwZM8xirKY2ybHecqwzIM96y7HOgHzrXRdefvllZGdnY/r06cjIyEBISAi2bdt216Q9UxNEc77ZLxERET0Qx+yJiIgsHJM9ERGRhWOyJyIisnBM9kRERBaOyb4G6sPjCuva3r170bdvX/j5+UEQBGzatEnqkEwuJiYGjzzyCJydneHl5YUBAwYgMTFR6rBMatmyZQgODtbfXCUsLAy//fab1GHVuQ8++ACCIGDs2LFSh2JSM2fOhCAIBkurVq2kDotMgMm+murL4wrrWklJCdq3b4+lS5dKHUqd2bNnD6KionDo0CHExcWhoqICvXr1QklJidShmYy/vz8++OADxMfH49ixY3jqqafQv39/nD17VurQ6szRo0fxxRdfIDg4WOpQ6kSbNm2Qnp6uX/bv3y91SGQKIlXLo48+KkZFRelfa7Va0c/PT4yJiZEwqroFQNy4caPUYdS5rKwsEYC4Z88eqUOpU25ubuLXX38tdRh1oqioSGzevLkYFxcndu3aVRwzZozUIZnUjBkzxPbt20sdBtUBtuyr4dbjCnv27KlfJ9XjCqnuFRQUAADc3d0ljqRuaLVarFu3DiUlJXV+a0+pREVFoU+fPgbnuKW7ePEi/Pz80LRpU0RERCAlJUXqkMgEeAe9aqhPjyukuqXT6TB27Fh07twZbdu2lTockzp9+jTCwsJQVlYGJycnbNy4EUFBQVKHZXLr1q3D8ePHcfToUalDqTOhoaFYtWoVWrZsifT0dMyaNQtPPPEEzpw5A2dnZ6nDo1rEZE9UBVFRUThz5owsxjNbtmyJkydPoqCgAD/88AMiIyOxZ88ei074qampGDNmDOLi4ur8yWhSeuaZZ/T/HxwcjNDQUAQGBmLDhg0YPny4hJFRbWOyr4b69LhCqjvR0dHYunUr9u7dK/kjleuCjY0NmjVrBgDo2LEjjh49ik8//RRffPGFxJGZTnx8PLKysvDwww/r12m1WuzduxefffYZ1Go1rKysJIywbri6uqJFixa4dOmS1KFQLeOYfTXUp8cVkumJoojo6Ghs3LgRu3btQpMmTaQOSRI6nQ5qtVrqMEyqR48eOH36NE6ePKlfOnXqhIiICJw8eVIWiR4AiouLcfnyZfj6+kodCtUytuyrqb48rrCuFRcXG/zaT05OxsmTJ+Hu7o5GjRpJGJnpREVFITY2Fj///DOcnZ2RkZEBAFCpVLC3t5c4OtOYMmUKnnnmGTRq1AhFRUWIjY3F7t27sX37dqlDMylnZ+e75mI4OjrCw8PDoudoTJgwAX379kVgYCCuX7+OGTNmwMrKCkOGDJE6NKplTPbVVF8eV1jXjh07hu7du+tfjx8/HgAQGRmJVatWSRSVaS1btgwA0K1bN4P1K1euxNChQ+s+oDqQlZWF119/Henp6VCpVAgODsb27dvx9NNPSx0amcC1a9cwZMgQ3LhxA56enujSpQsOHToET09PqUOjWsZH3BIREVk4jtkTERFZOCZ7IiIiC8dkT0REZOGY7ImIiCwckz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMZaejQoRgwYID+dbdu3TB27Ng6j2P37t0QBAH5+fn3LSMIAjZt2lTlY86cORMhISFGxXXlyhUIgoCTJ08adRwiqjkme7JIQ4cOhSAIEARB/xS32bNnQ6PRmPy9f/rpJ8yZM6dKZauSoImIjMV745PF6t27N1auXAm1Wo1ff/0VUVFRsLa2xpQpU+4qW15eDhsbm1p5X3d391o5DhFRbWHLniyWra0tfHx8EBgYiFGjRqFnz57YvHkzgNtd73PnzoWfnx9atmwJAEhNTcVLL70EV1dXuLu7o3///rhy5Yr+mFqtFuPHj4erqys8PDzw7rvv4p+Pl/hnN75arcakSZMQEBAAW1tbNGvWDCtWrMCVK1f0Dxdyc3ODIAj6B+zodDrExMSgSZMmsLe3R/v27fHDDz8YvM+vv/6KFi1awN7eHt27dzeIs6omTZqEFi1awMHBAU2bNsW0adNQUVFxV7kvvvgCAQEBcHBwwEsvvYSCggKD7V9//TVat24NOzs7tGrVCp9//nm1YyEi02GyJ9mwt7dHeXm5/vXOnTuRmJiIuLg4bN26FRUVFQgPD4ezszP27duHP//8E05OTujdu7d+v08++QSrVq3CN998g/379yM3NxcbN2781/d9/fXX8d1332Hx4sVISEjAF198AScnJwQEBODHH38EACQmJiI9PR2ffvopACAmJgZr1qzB8uXLcfbsWYwbNw6vvvoq9uzZA6DyR8nAgQPRt29fnDx5Em+++SYmT55c7b+Js7MzVq1ahXPnzuHTTz/FV199hYULFxqUuXTpEjZs2IAtW7Zg27ZtOHHiBN5++2399rVr12L69OmYO3cuEhISMG/ePEybNg2rV6+udjxEZCIikQWKjIwU+/fvL4qiKOp0OjEuLk60tbUVJ0yYoN/u7e0tqtVq/T7ffvut2LJlS1Gn0+nXqdVq0d7eXty+fbsoiqLo6+srzp8/X7+9oqJC9Pf317+XKIpi165dxTFjxoiiKIqJiYkiADEuLu6ecf7xxx8iADEvL0+/rqysTHRwcBAPHDhgUHb48OHikCFDRFEUxSlTpohBQUEG2ydNmnTXsf4JgLhx48b7bv/oo4/Ejh076l/PmDFDtLKyEq9du6Zf99tvv4kKhUJMT08XRVEUH3roITE2NtbgOHPmzBHDwsJEURTF5ORkEYB44sSJ+74vEZkWx+zJYm3duhVOTk6oqKiATqfDK6+8gpkzZ+q3t2vXzmCc/tSpU7h06RKcnZ0NjlNWVobLly+joKAA6enpCA0N1W9TKpXo1KnTXV35t5w8eRJWVlbo2rVrleO+dOkSSktL73qGfHl5OTp06AAASEhIMIgDAMLCwqr8HresX78eixcvxuXLl1FcXAyNRgMXFxeDMo0aNULDhg0N3ken0yExMRHOzs64fPkyhg8fjhEjRujLaDQaqFSqasdDRKbBZE8Wq3v37li2bBlsbGzg5+cHpdLw4+7o6Gjwuri4GB07dsTatWvvOpanp2eNYrC3t6/2PsXFxQCAX375xSDJApXzEGrLwYMHERERgVmzZiE8PBwqlQrr1q3DJ598Uu1Yv/rqq7t+fFhZWdVarERkHCZ7sliOjo5o1qxZlcs//PDDWL9+Pby8vO5q3d7i6+uLw4cP48knnwRQ2YKNj4/Hww8/fM/y7dq1g06nw549e9CzZ8+7tt/qWdBqtfp1QUFBsLW1RUpKyn17BFq3bq2fbHjLoUOHHlzJOxw4cACBgYF477339OuuXr16V7mUlBRcv34dfn5++vdRKBRo2bIlvL294efnh6SkJERERFTr/Ymo7nCCHtHfIiIi0KBBA/Tv3x/79u1DcnIydu/ejdGjR+PatWsAgDFjxuCDDz7Apk2bcP78ebz99tv/eo1848aNERkZiTfeeAObNm3SH3PDhg0AgMDAQAiCgK1btyI7OxvFxcVwdnbGhAkTMG7cOKxevRqXL1/G8ePHsWTJEv2kt7feegsXL17ExIkTkZiYiNjYWKxatapa9W3evDlSUlKwbt06XL58GYsXL77nZEM7OztERkbi1KlT2LdvH0aPHo2XXnoJPj4+AIBZs2YhJiYGixcvxoULF3D69GmsXLkSCxYsqFY8RGQ6TPZEf3NwcMDevXvRqFEjDBw4EK1bt8bw4cNRVlamb+n/97//xWuvvYbIyEiEhYXB2dkZzz///L8ed9myZXjhhRfw9ttvo1WrVhgxYgRKSkoAAA0bNsSsWbMwefJkeHt7Izo6GgAwZ84cTJs2DTExMWjdujV69+6NX375BU2aNAFQOY7+448/YtOmTWjfvj2WL1+OefPmVau+/fr1w7hx4xAdHY2QkBAcOHAA06ZNu6tcs2bNMHDgQDz77LPo1asXgoODDS6te/PNN/H1119j5cqVaNeuHbp27YpVq1bpYyUi6Qni/WYWERERkUVgy56IiMjCMdkTERFZOCZ7IiIiC8dkT0REZOGY7ImIiCwckz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMREVk4JnsiIiIL9/+PB+TCwoNgQQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "new = OrdinalClassifier(LogisticRegression(max_iter=1e4))\n",
+    "new.fit(X,y)\n",
+    "\n",
+    "new_pred=evaluate(X,y,new)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "a9dd2940-9a74-49b0-9ae5-9762b547d719",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transfer learned classifiers\n",
+    "old = OrdinalClassifierOG(LogisticRegression(max_iter=1e4))\n",
+    "old.clf = new.clf\n",
+    "old.clfs = new.clfs\n",
+    "old.uniques_class = new.uniques_class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "8a42b46b-a94b-44b3-b906-f0e7fffc4aed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/mamiglia/.local/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1334: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, msg_start, len(result))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cohen = 0.48285419301389243 \n",
+      "Recall = 0.5892466395748671 \n",
+      "Precision = 0.5552267609453678 \n",
+      "Accuracy = 0.5892466395748671\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAGwCAYAAACuFMx9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAABZpElEQVR4nO3deVwU9f8H8Ncsy30sh5yCqHmiIqZFpKWmiWUeaYdGhWb6zSCvr6b+8jalrNQ00w7z6CupHZpaqaR55Y1HHogHKIiccoMs7O78/iBXNzWBZRl25/V8POZRO/OZ2fcHd/a9n2NmBFEURRAREZHFUkgdABEREZkWkz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMREVk4JnsiIiILp5Q6AGPodDpcv34dzs7OEARB6nCIiKiaRFFEUVER/Pz8oFCYrv1ZVlaG8vJyo49jY2MDOzu7Woiobpl1sr9+/ToCAgKkDoOIiIyUmpoKf39/kxy7rKwMTQKdkJGlNfpYPj4+SE5ONruEb9bJ3tnZGQDQBc9CCWuJoyFTE5Rm/XGtMVFr/BeUWeLNPWVBgwrsx6/673NTKC8vR0aWFlfjG8PFuea9B4VFOgR2vILy8nIm+7p0q+teCWsoBSZ7SycIZv1xrTFRkOvUGiZ7Wfj7n7kuhmKdnAU4Odf8fXQw3+FieX57EhGR7GhFHbRG/IbUirraC6aOMdkTEZEs6CBCZ0SPkTH7Sk2u/YNERESywZY9ERHJgg46GNMRb9ze0mKyJyIiWdCKIrRGXOVhzL5SYzc+ERGRhWPLnoiIZEHOE/SY7ImISBZ0EKGVabJnNz4REZGFY8ueiIhkgd34REREFo6z8YmIiMhisWVPRESyoPt7MWZ/c8VkT0REsqA1cja+MftKjcmeiIhkQSvCyKfe1V4sdY1j9kRERBaOLXsiIpIFjtkTERFZOB0EaCEYtb+5Yjc+ERGRhWPLnoiIZEEnVi7G7G+umOyJiEgWtEZ24xuzr9TYjU9ERGTh2LInIiJZYMueqqXv0BysPnwOW5L+wqdbL6JlSKnUIdUJS69320eLMPObS1h79C9sS4lHWK/8+5Z9Z95VbEuJx4DhmXUXoAReisrE9rSTeGvWNalDqROW/hm/FznVWScKRi/mql4k+6VLl6Jx48aws7NDaGgojhw5InVI99W1Xx5GzriOtQt8EBXeAknn7DA3NgkqjwqpQzMpOdTbzkGH5HP2WDo14F/LPR6eh1YdSpCTYV1HkUmjRftS9Hn1BpLO2UkdSp2Qw2f8n+RYZ7mSPNmvX78e48ePx4wZM3D8+HG0b98e4eHhyMrKkjq0exo4MgfbYt2xY707Ui7aYfEkf6hvCggfkit1aCYlh3of263C6o8b4sB2t/uW8fAux6jZqZg/pgm0Feb7K/9B7By0mPTZVSx6NwBF+VZSh1Mn5PAZ/ye51flWN74xi7mSPNkvWLAAI0aMwLBhwxAUFITly5fDwcEB33zzjdSh3UVprUPz4FIc3+esXyeKAk7sc0ZQR8vt+pJrvf9JEERMXHQFP3zhjasX7KUOx6Si513DkZ0uOHHHv7klk+NnXI511kJh9GKuJI28vLwc8fHx6Nmzp36dQqFAz549cfDgwbvKq9VqFBYWGix1ycVdCyslkJ9tOK8xL0cJN09NncZSl+Ra73966e0MaLXAz994SR2KSXXtl4dmbW/imxhfqUOpM3L8jMuxzqKR4/Uix+xrJicnB1qtFt7e3gbrvb29kZGRcVf5mJgYqFQq/RIQ8O9jq0S1pVm7EvQfloVP/tsYMOOuvAfx9CvHqNlp+PCdQFSozbcVQ0SGzOrSuylTpmD8+PH614WFhXWa8AtzraDVAK7/+NXr1kCDvGyz+lNWi1zrfae2jxbDtYEG3x48rV9npQRGTL2G59/IQmTndhJGV3uatSuFm6cGS7cl6tdZKYF2j5Wg39AcPNekPXQ6y/uxI8fPuBzrLOdL7yT9F23QoAGsrKyQmWl4+VJmZiZ8fHzuKm9rawtbW9u6Cu8umgoFLv7lgA5dinBwmwpA5ThuSJdibF7lIVlcpibXet9p548eOLHPxWDd3P9dxM6f3BG3oYFEUdW+k/udMfKplgbr/rsgBamX7bBhqZdFJnpAnp9xOdZZKyqgFWveY2XOz7OXNNnb2NigY8eO2LlzJwYMGAAA0Ol02LlzJ6Kjo6UM7b5++rIBJixKxYVTDkg84YDnR2TDzkGHHevcpQ7NpORQbzsHLfwaq/WvfQLUaBpUiqJ8JbKv26Ao3/B00VYIyMu2xrUky7k07WaJFa4mGk4+LCtVoCjv7vWWRg6f8X+SY53lSvK+mvHjxyMyMhKdOnXCo48+ikWLFqGkpATDhg2TOrR72rPZDSoPLV6fmAE3Tw2SztrjvYgmyM+x7Guu5VDvFsGlmL/hgv71f2ZU3kgm7nuPv8fqyZLJ4TP+T3Krsw4CdEZMVdPBfJv2giiKkkf/2Wef4aOPPkJGRgZCQkKwePFihIaGPnC/wsJCqFQqdEN/KAXL/HDSbYJS8t+mkhC1WqlDkIb0X01UBzRiBXbjZxQUFMDFxeXBO9TArVyx+a+H4Ohc8/tGlBRp0S/4skljNZV68e0ZHR1db7vtiYiIzF29SPZERESmZvwEPfPtbWKyJyIiWagcs6/5FSXG7Cs13jWDiIjIwrFlT0REsqAz8v725jwbn8meiIhkgWP2REREFk4HhWyvs+eYPRERkYVjy56IiGRBKwrQGvGYWmP2lRqTPRERyYLWyAl6WnbjExERUX3Flj0REcmCTlRAZ8RsfB1n4xMREdVv7MYnIiIii8WWPRERyYIOxs2o19VeKHWOyZ6IiGTB+JvqmG9nuPlGTkRERFXClj0REcmC8ffGN9/2MZM9ERHJgpyfZ89kT0REsiDnlr35Rk5ERERVwpY9ERHJgvE31THf9jGTPRERyYJOFKAz5jp7M37qnfn+TCEiIqIqYcueiIhkQWdkN74531SHyZ7MhsLNTeoQJCEWFUkdgiR0ZWVSh0AWxvin3plvsjffyImIiKhK2LInIiJZ0EKA1ogb4xizr9SY7ImISBbYjU9EREQWiy17IiKSBS2M64rX1l4odY7JnoiIZEHO3fhM9kREJAt8EA4RERHVKq1Wi2nTpqFJkyawt7fHQw89hDlz5kAURX0ZURQxffp0+Pr6wt7eHj179sTFixcNjpObm4uIiAi4uLjA1dUVw4cPR3FxcbViYbInIiJZEP9+nn1NF7Ga4/0ffvghli1bhs8++wwJCQn48MMPMX/+fCxZskRfZv78+Vi8eDGWL1+Ow4cPw9HREeHh4Si746ZSEREROHv2LOLi4rB161bs3bsXI0eOrFYs7MYnIiJZqOtu/AMHDqB///7o06cPAKBx48b47rvvcOTIEQCVrfpFixZh6tSp6N+/PwBgzZo18Pb2xqZNmzB48GAkJCRg27ZtOHr0KDp16gQAWLJkCZ599ll8/PHH8PPzq1IsbNkTERFVQ2FhocGiVqvvWe7xxx/Hzp07ceHCBQDAqVOnsH//fjzzzDMAgOTkZGRkZKBnz576fVQqFUJDQ3Hw4EEAwMGDB+Hq6qpP9ADQs2dPKBQKHD58uMoxs2VPRESyUFuPuA0ICDBYP2PGDMycOfOu8pMnT0ZhYSFatWoFKysraLVazJ07FxEREQCAjIwMAIC3t7fBft7e3vptGRkZ8PLyMtiuVCrh7u6uL1MVTPZERCQLWiOfendr39TUVLi4uOjX29ra3rP8hg0bsHbtWsTGxqJNmzY4efIkxo4dCz8/P0RGRtY4jppgsiciIqoGFxcXg2R/PxMnTsTkyZMxePBgAEC7du1w9epVxMTEIDIyEj4+PgCAzMxM+Pr66vfLzMxESEgIAMDHxwdZWVkGx9VoNMjNzdXvXxUcsyciIlm41Y1vzFIdpaWlUCgM06yVlRV0Oh0AoEmTJvDx8cHOnTv12wsLC3H48GGEhYUBAMLCwpCfn4/4+Hh9mV27dkGn0yE0NLTKsbBlT0REsqCDAjoj2rjV3bdv376YO3cuGjVqhDZt2uDEiRNYsGAB3njjDQCAIAgYO3Ys3n//fTRv3hxNmjTBtGnT4OfnhwEDBgAAWrdujd69e2PEiBFYvnw5KioqEB0djcGDB1d5Jj7AZE9ERGQSS5YswbRp0/D2228jKysLfn5++M9//oPp06fry7z77rsoKSnByJEjkZ+fjy5dumDbtm2ws7PTl1m7di2io6PRo0cPKBQKDBo0CIsXL65WLIJ45618zExhYSFUKhW6oT+UgrXU4ZCJWXl6Sh2CJMSiIqlDkITujpuKkOXSiBXYjZ9RUFBQpXHwmriVK0btGwhbp5rnCnVxBZY98ZNJYzUVtuyJiEgWauvSO3PEZE9ERLIgGvnUO5EPwiEiIqL6ii17IiKSBS0EaKv5MJt/7m+umOyJiEgWdKJx4+46s53Ozm58IiIii8eWfQ30HZqDF0Zlwd1Tg6Rz9vh8akMknnSQOiyTs/R6e3iVYdjYS+jU+QZs7bRIT7XHwultcPHcrUtsRLz6dhJ6D0yDo7MG5066YuncVrieYr5/g5dGpaFzeB78m95EeZkC544745sPA5CWbG9QrlWHIkT+9xpahRRDpwUuJzhiamQrlKsto73wcnQmOj9bgIBm6sq/wzEHrJjri2uX7R68s5mz9PP6TjojJ+gZs6/UzDdyiXTtl4eRM65j7QIfRIW3QNI5O8yNTYLKo0Lq0EzK0uvt5FyBj1cdg1YjYHpUCN4aGIavPmmBosLbv4dfGHYV/Yak4rP3W2Hcq4+g7KYCc5adgLWNVsLIjdPu0SJs+dYb4wa1wf+93gpKaxFz15yHrf3tOrXqUIT3VyXi+H4VxjzfBqMHtMWWNd4w3zt03C04rARbVjXA2OeaY8rgprBSipj3XZLB38ESWfp5/U86CEYv5krSZL9371707dsXfn5+EAQBmzZtkjKcKhk4MgfbYt2xY707Ui7aYfEkf6hvCggfkit1aCZl6fV+4Y0ryM60w8LpbXDhjAqZafY4cdADGddutXBEDIhIwbqvmuDQbi9cueiMT6a2hYenGmFPZUsauzGmDWuF33/0RMpFBySfd8SCiU3h3bAczduW6Mv8Z+pV/LzKG98v90PKRQekJdtj368eqCi3nLbCexFNEbfBHVcv2CHpnD0+GdsI3v4VaB58U+rQTMrSz2u6TdKztaSkBO3bt8fSpUulDKPKlNY6NA8uxfF9zvp1oijgxD5nBHUslTAy05JDvR/rmoOLZ50x5aO/EPvHHixZfwjhA9P0230a3oS7ZzlOHnbXrystViLxtAtaBxdIEbJJODhXtmSLCip7NFQeFWjVoQQFN6zxyfdnEXskHvO/O4c2nSz7rn6OLn//HfKtJI7EdORwXv+TVhSMXsyVpGP2zzzzDJ555hkpQ6gWF3ctrJRAfrbhny0vR4mAZmqJojI9OdTbx/8m+ryUho3fNsL6FY3Rok0h3pqUCE2FgJ1b/ODWoBwAkHfDxmC//Bs2+m3mThBE/GfaVZw95oSrFyp7NHwDKm9ZGzEmDV/HNELSOQf0GJiDmG8T8NYzwbh+xfLGtAVBxFuz0nDmiAOuJto/eAczJYfz+p/kPGZvVhP01Go11OrbH8LCwkIJoyFLIihEXDzrgtVLmgEAks67ILBZCZ59MQ07t1T9yVLmLGr2FTRuUYoJLwXp1wl/f7f9+p0X4n6ofDbB5XOOCHm8AL1ezMKqjxpJEapJRc9LQ2CrMvx3QDOpQyGqNWb1MyUmJgYqlUq/BAQE1On7F+ZaQasBXD01BuvdGmiQl21Wv5uqRQ71zsu2RWqSo8G61CRHePpWtmzzcipb9G4ehq14V49y/TZzNmrmFTzaPR+TXmmNnAxb/frcrMqHhqRcNGzhplyyh5efZfRo3Clq7jWEPl2Id194CDnp5v/v+m/kcF7/kw5GPs+eE/TqxpQpU1BQUKBfUlNT6/T9NRUKXPzLAR263B6vFAQRIV2KcS7eMi9VAeRR73MnVWjY2HCcsmFgCbKuV3ZTZ6TZIzfbBu1Db09csnfUoGW7QiT8parTWGuXiFEzr+DxXrmY/GprZF4z7JbPvGaLnAxr+Dc1nKjm36QMmWm2sBwiouZew+O9C/Duiw8hM9WS6nZvcjiv/0k0cia+aMbJ3qx+vtna2sLWVtqT8KcvG2DColRcOOWAxBMOeH5ENuwcdNixzv3BO5sxS6/3xv81wierj+Gl4cnYt8MbLdsW4pkX0rB4duu/SwjYtLYRBo9IxvWrDshMs8drUZdxI9sWB3eZ76N3o2ZfQbd+NzB7ZAvcLFbo5x+UFCn/voZewI9f+eLVsWlIPu+Ay+cc0XNgNvwfuom5Uc2lDb4WRc9LQ/fn8zBzWJPKv4Nn5aVnJUVWKC8zqzZRtVj6ef1PfOodVdmezW5QeWjx+sQMuHlqkHTWHu9FNEF+Ts2fkWwOLL3eF8+q8P74YAwdfQmv/CcZGWl2+GJ+S+z+1Vdf5oeVgbCz1+Kd6Qlwctbg7AlXTH87BBXl5jtj+7lXswAA89clGKz/ZGJT/P5j5Y+YTSt9YW0rYuR7KXB21SApwQHvvd4a6SmWMzmv79AbAICPf7pssP7jsQGI22CZiQ+w/POabhNEUbpbYxQXF+PSpUsAgA4dOmDBggXo3r073N3d0ajRgyf+FBYWQqVSoRv6Qynww2nprDzNtwVtDLHIsi9zux9dWZnUIVAd0IgV2I2fUVBQABcXlwfvUAO3csXzccNg7VjzuRgVJeXY+PRKk8ZqKpK27I8dO4bu3bvrX48fPx4AEBkZiVWrVkkUFRERWSJ240ukW7dukLBjgYiISBY4Zk9ERLJg7P3tzfnSOyZ7IiKSBTl341vuNSVEREQEgC17IiKSCTm37JnsiYhIFuSc7NmNT0REZOHYsiciIlmQc8ueyZ6IiGRBhHGXz5nzXWGY7ImISBbk3LLnmD0REZGFY8ueiIhkQc4teyZ7IiKSBTkne3bjExERWTi27ImISBbk3LJnsiciIlkQRQGiEQnbmH2lxm58IiIiC8eWPRERyQKfZ09ERGTh5Dxmz258IiIiC8eWPRERyYKcJ+gx2RMRkSzIuRufyZ6IiGRBzi17jtkTERFZOLbsyWz8eipO6hAk8ch7o6QOQRLuq49IHULd02mljsCiiUZ245tzy57JnoiIZEEEIIrG7W+u2I1PRERk4diyJyIiWdBBgMA76BEREVkuzsYnIiIii8WWPRERyYJOFCDwpjpERESWSxSNnI1vxtPx2Y1PRERk4diyJyIiWZDzBD0meyIikgUmeyIiIgsn5wl6HLMnIiKycGzZExGRLMh5Nj6TPRERyUJlsjdmzL4Wg6lj7MYnIiKycGzZExGRLHA2PhERkYUTYdwz6c24F5/d+ERERJaOLXsiIpIFduMTERFZOhn347Mbn4iI5OHvln1NF9SgZZ+WloZXX30VHh4esLe3R7t27XDs2LHbIYkipk+fDl9fX9jb26Nnz564ePGiwTFyc3MREREBFxcXuLq6Yvjw4SguLq5WHEz2REREJpCXl4fOnTvD2toav/32G86dO4dPPvkEbm5u+jLz58/H4sWLsXz5chw+fBiOjo4IDw9HWVmZvkxERATOnj2LuLg4bN26FXv37sXIkSOrFQu78YmISBbq+g56H374IQICArBy5Ur9uiZNmtxxPBGLFi3C1KlT0b9/fwDAmjVr4O3tjU2bNmHw4MFISEjAtm3bcPToUXTq1AkAsGTJEjz77LP4+OOP4efnV6VY2LInIiJZMKYL/87JfYWFhQaLWq2+5/tt3rwZnTp1wosvvggvLy906NABX331lX57cnIyMjIy0LNnT/06lUqF0NBQHDx4EABw8OBBuLq66hM9APTs2RMKhQKHDx+uct2Z7ImIiKohICAAKpVKv8TExNyzXFJSEpYtW4bmzZtj+/btGDVqFEaPHo3Vq1cDADIyMgAA3t7eBvt5e3vrt2VkZMDLy8tgu1KphLu7u75MVbAbvwb6Ds3BC6Oy4O6pQdI5e3w+tSESTzpIHZbJWVq9S4sVWD3fFwd+UyH/hhIPtbmJUXOuoWXITQBAXrYSK+b6IX6PM0oKrND2sWJEvX8NDZuW649x/YoNvprth7NHnFBRLqBj90JEvZ8GN0+NVNX6V4MePYtBoWfh61oEAEjKcseKPzriwIVGAIDnHzmH8OCLaOmXAye7CnSfMwzFZbYGx/jk1d/QwvcG3BxvoqjMFkcuNcSS7Y8hp8ixzutTU21Di/DiW5lo3u4mPHwqMHN4Uxzc7npHCRGvT0hH7yE5cFJpce6oExb/XwCuJ9tJFbLJWNp5/a9qOMnOYH8AqampcHFx0a+2tbW9Z3GdTodOnTph3rx5AIAOHTrgzJkzWL58OSIjI2seRw2wZV9NXfvlYeSM61i7wAdR4S2QdM4Oc2OToPKokDo0k7LEei/8bwCO73XCu0uuYvnO8+jYtQiTX26GnHRriCIw640mSL9qg5krk7B0RyK8/csx+eVmKCutPG3KShX4vyEPQRCAD7+/hAU/X4SmXIHpkU2g00lcufvIKnTEZ9tD8frngxD5+SAcS/LDxxHb0NQrFwBgZ63BwYuNsGrPw/c9xrEkP0xZ9zReWDQYk2J7wd+9EB8O2VFXVagVdg46JJ1zwGdTA+65/aW3M9F/WDaWTGmEMX1boqxUgXn/uwRr23r6D1tDlnhe/5tbY/bGLADg4uJisNwv2fv6+iIoKMhgXevWrZGSkgIA8PHxAQBkZmYalMnMzNRv8/HxQVZWlsF2jUaD3NxcfZmqkDTZx8TE4JFHHoGzszO8vLwwYMAAJCYmShnSAw0cmYNtse7Ysd4dKRftsHiSP9Q3BYQPyZU6NJOytHqrbwrY/6sr3pyajnaPlaBhk3K8NiEDfo3V2LrGA2lJtkiId8Q7H1S29AOaqfHOB9egLhPwx0ZXAMDZI47ITLXBfxeloEnrMjRpXYaJn17FxVMOOLnfSdoK3se+841x4EIgUm+4IuWGK5bFhaK03BptAyq/bL47EIzVezvgdKrXfY/x3YH2OJPqjYx8Z/yV4oPVezugbUAmrBTauqqG0Y79ocLqj/xwYJvrPbaKGDA8C98t9sHBHa5ITnDA/LGN4eFdgcfD8+s4UtOytPO6vuncufNdOe3ChQsIDAwEUDlZz8fHBzt37tRvLywsxOHDhxEWFgYACAsLQ35+PuLj4/Vldu3aBZ1Oh9DQ0CrHImmy37NnD6KionDo0CHExcWhoqICvXr1QklJiZRh3ZfSWofmwaU4vs9Zv04UBZzY54ygjqUSRmZallhvrVaATivA5h8tNVs7nb5LHoDBdoUCsLYRcfZoZSKvKBcAoXLdLda2IgQFcPZI/Uz2d1IIOjzd7hLsbSpwOsX7wTvcg4t9GXq3v4i/Unyg1VnVcoTS8GlUDg9vjcHnvbTICudPOqJ1x/r53VQTlnheP5BYC0s1jBs3DocOHcK8efNw6dIlxMbG4ssvv0RUVBQAQBAEjB07Fu+//z42b96M06dP4/XXX4efnx8GDBgAoLInoHfv3hgxYgSOHDmCP//8E9HR0Rg8eHCVZ+IDEo/Zb9u2zeD1qlWr4OXlhfj4eDz55JN3lVer1QazHgsLC00e451c3LWwUgL52YZ/trwcJQKa3Xs2piWwxHo7OOnQumMJYhf5oFHzK3D11GD3JjckxDvCr7EaAc3K4NWwHN/E+GLMh9dg56DDT196IifdBrmZlX+HVh1LYOegw4q5fhg2+ToAASvm+kKnFZCbVX+nwzzkfQPf/GcjbJRa3Cy3xsS14UjOdq/WMaLDD+Glx87A3kaDv1K8MX7NMyaKtu65e1Z2YefnWBusz89W6rdZAks8rx+krm+X+8gjj2Djxo2YMmUKZs+ejSZNmmDRokWIiIjQl3n33XdRUlKCkSNHIj8/H126dMG2bdtgZ3d7fsjatWsRHR2NHj16QKFQYNCgQVi8eHG1YqnSN9LmzZurfMB+/fpVK4A7FRQUAADc3e/9xRMTE4NZs2bV+PhEd3p3yVUsGN8IrzzcFgorEc3alaLbgDxc/MsBSmtg+opkLBjfCC8EtYPCSkSHJ4rwyFOF+nE7Vw8tpn5xBUum+OPnFQ0gKIDuA/LQrF0phHo8G+ZqjisiPnsRTnbl6NE2CTNf+AP/+apftRL+t/vaY/OxVvBxLcKIp+Ix88VdGLfmGQDme+9wIlN47rnn8Nxzz913uyAImD17NmbPnn3fMu7u7oiNjTUqjiol+1vdCQ8iCAK02pqN2+l0OowdOxadO3dG27Zt71lmypQpGD9+vP51YWEhAgLuPcHGFApzraDVAK7/mGnt1kCDvOz625IzlqXW269xOT7+6RLKShUoKVLAw1uDuf8JhG9gZaumefBNLPs9ESWFClRUCHD10GJ0n+ZoEXy7i7NjtyKsOpiAghtWsFICTiotBrdvA99G9bdlpNFa4VquCgBw/ronghpmYfDjpxHzc9cqH6Og1B4FpfZIueGKK9lu+GXS/9AuIBOnU6s+Yai+ys2ubNG7NqhAbtbt1r2rpwaXz9pLFVats9Tz+oHM+P72xqhS+0On01VpqWmiB4CoqCicOXMG69atu28ZW1vbu2ZB1iVNhQIX/3JAhy5F+nWCICKkSzHOxVvopSqw/HrbOejg4a1BUb4V4ve4ICzccHjI0UUHVw8t0pJscPGUw13bAUDloYWTSouT+52Qn6PEY73qdojJGIIgwkZZ83NXECq/Pa2NOEZ9kpFigxuZSoPPu4OTFq1CSpAQbz6XFz6IpZ/X91JbN9UxR0b9fCsrKzMYV6ip6Oho/f1+/f39jT6eKf30ZQNMWJSKC6cckHjCAc+PyIadgw471lVvzNPcWGK9j+12higCAQ+pkZZsg6/nNERAszL0evkGAGDvFhVUHlp4NSxHcoIdlk/3R1jvAnTsdvvLcfs6dzRqXgaVhwYJ8Y5YNr0hnh+ZXW/HPKN6HcaBCwHIyHeCg20Fere/hI5NruOdVX0AAB5OpfBwLkWAR+WPlWbeuSgtt0ZGvhMKb9qhjX8mgvyzceqqDwpv2sLfvRBv9TyC1BsuOJ1iPq16Owct/Brf/jfyCVCjaVApivKVyL5ug00rvDBkdAbSkm2RkWqLyAnXcSPTGgcMrsU3f5Z4Xv8rGT/1rtrJXqvVYt68eVi+fDkyMzNx4cIFNG3aFNOmTUPjxo0xfPjwKh9LFEW888472LhxI3bv3m1wz+D6as9mN6g8tHh9YgbcPDVIOmuP9yKa3DWZx9JYYr1LCq2wMsYXOenWcHbVovOz+Rg2OR3Kv6uUm2mNL2Y2RH6OEu5eGvR8MRevjDW8HvbaZVusjPFFUb4VvAPKMWR0JgaOzJagNlXj5ngTM1/YhQbOpSgus8GlDA+8s6oPjlyuHA4b+OhZjOxx+xKfr0b+DACY9UM3bD3RCmUVSnQPSsLIHkdhb61BTpEDDl4MwDe7H0aF1nxm47doX4qPvr/9ZLG3ZqYBAHZscMcn4xtjw+fesHPQYcyHKXBy0eLsUSe892ozVKjr8WSMGrDE85ruTRDF6t3af/bs2Vi9ejVmz56NESNG4MyZM2jatCnWr1+PRYsW6e/nWxVvv/02YmNj8fPPP6Nly5b69SqVCvb2Dx4bKywshEqlQjf0h1Lgh9PSbb9+UuoQJPHIe6OkDkES7quPSB1C3dNZxlBIdWjECuzGzygoKDDZ0OytXBGwfCYU9jXvjdbdLEPqWzNNGqupVPtn6po1a/Dll18iIiICVla3f8m3b98e58+fr9axli1bhoKCAnTr1g2+vr76Zf369dUNi4iI6N/V8XX29Um1u/HT0tLQrFmzu9brdDpUVFTvGtRqdioQERFRDVS7ZR8UFIR9+/bdtf6HH35Ahw4daiUoIiKiWseWfdVNnz4dkZGRSEtLg06nw08//YTExESsWbMGW7duNUWMRERExqulp96Zo2q37Pv3748tW7bg999/h6OjI6ZPn46EhARs2bIFTz/9tCliJCIiIiPU6Dr7J554AnFxcbUdCxERkcnc+Zjamu5vrmp8U51jx44hISEBQOU4fseOHWstKCIiolrHm+pU3bVr1zBkyBD8+eefcHV1BQDk5+fj8ccfx7p16+r9HfCIiIjkptpj9m+++SYqKiqQkJCA3Nxc5ObmIiEhATqdDm+++aYpYiQiIjLerQl6xixmqtot+z179uDAgQMGd7xr2bIllixZgieeeKJWgyMiIqotgli5GLO/uap2sg8ICLjnzXO0Wi38/PxqJSgiIqJaJ+Mx+2p343/00Ud45513cOzYMf26Y8eOYcyYMfj4449rNTgiIiIyXpVa9m5ubhCE22MVJSUlCA0NhVJZubtGo4FSqcQbb7yBAQMGmCRQIiIio8j4pjpVSvaLFi0ycRhEREQmJuNu/Col+8jISFPHQURERCZS45vqAEBZWRnKy8sN1pnbM36JiEgmZNyyr/YEvZKSEkRHR8PLywuOjo5wc3MzWIiIiOolGT/1rtrJ/t1338WuXbuwbNky2Nra4uuvv8asWbPg5+eHNWvWmCJGIiIiMkK1u/G3bNmCNWvWoFu3bhg2bBieeOIJNGvWDIGBgVi7di0iIiJMEScREZFxZDwbv9ot+9zcXDRt2hRA5fh8bm4uAKBLly7Yu3dv7UZHRERUS27dQc+YxVxVO9k3bdoUycnJAIBWrVphw4YNACpb/LcejENERET1R7WT/bBhw3Dq1CkAwOTJk7F06VLY2dlh3LhxmDhxYq0HSEREVCtkPEGv2mP248aN0/9/z549cf78ecTHx6NZs2YIDg6u1eCIiIjIeEZdZw8AgYGBCAwMrI1YiIiITEaAkU+9q7VI6l6Vkv3ixYurfMDRo0fXOBgiIiKqfVVK9gsXLqzSwQRBYLInk2m36G2pQ5BE17fjpQ5BEsnbPKUOoc5p0jOkDsGyyfjSuyol+1uz74mIiMwWb5dLRERElsroCXpERERmQcYteyZ7IiKSBWPvgierO+gRERGReWHLnoiI5EHG3fg1atnv27cPr776KsLCwpCWlgYA+Pbbb7F///5aDY6IiKjWyPh2udVO9j/++CPCw8Nhb2+PEydOQK1WAwAKCgowb968Wg+QiIiIjFPtZP/+++9j+fLl+Oqrr2Btba1f37lzZxw/frxWgyMiIqotcn7EbbXH7BMTE/Hkk0/etV6lUiE/P782YiIiIqp9Mr6DXrVb9j4+Prh06dJd6/fv34+mTZvWSlBERES1jmP2VTdixAiMGTMGhw8fhiAIuH79OtauXYsJEyZg1KhRpoiRiIiIjFDtbvzJkydDp9OhR48eKC0txZNPPglbW1tMmDAB77zzjiliJCIiMpqcb6pT7WQvCALee+89TJw4EZcuXUJxcTGCgoLg5ORkiviIiIhqh4yvs6/xTXVsbGwQFBRUm7EQERGRCVQ72Xfv3h2CcP8Zibt27TIqICIiIpMw9vI5ObXsQ0JCDF5XVFTg5MmTOHPmDCIjI2srLiIiotrFbvyqW7hw4T3Xz5w5E8XFxUYHRERERLWr1p569+qrr+Kbb76prcMRERHVLhlfZ19rT707ePAg7OzsautwREREtYqX3lXDwIEDDV6Looj09HQcO3YM06ZNq7XAiIiIqHZUO9mrVCqD1wqFAi1btsTs2bPRq1evWguMiIiIake1kr1Wq8WwYcPQrl07uLm5mSomIiKi2ifj2fjVmqBnZWWFXr168el2RERkduT8iNtqz8Zv27YtkpKSTBELERERmUC1x+zff/99TJgwAXPmzEHHjh3h6OhosN3FxaXWgquv+g7NwQujsuDuqUHSOXt8PrUhEk86SB2WyVlSvV8KPoOX252Fn0sRAOByrjuWH+6I/VcCAQD+qgJMeOIgOvilw8ZKiz+vNkLM7i64UXq7voGu+fjvEwcR4pcBa4UWF3I88NnBR3H0WkNJ6lQVyf3U0KTfvV71ggJek6wBADf/0uHGMg3KzogQrACbFgIaLraGwq7yzpll53XIWaKB+pwIWAFO3RXwHKeEwsF8nvX9zZY98PYru2v91g0BWPZhEKL/7yxCQm/AvYEaZTetkHDKFSuXtMC1K5b3DBBLOq+rxIxb58aocst+9uzZKCkpwbPPPotTp06hX79+8Pf3h5ubG9zc3ODq6lrtcfxly5YhODgYLi4ucHFxQVhYGH777bdqV6Iude2Xh5EzrmPtAh9EhbdA0jk7zI1NgsqjQurQTMrS6p1Z5IRFfz6Gl797AYO/ewGHUxticd9teMg9F/bKCnz5/FaIAN78sR9e3/A8rK20WNLvNwh3fFN81v9XWCl0ePPHfnj5uxcqk33/X+HhUCpdxR4gYLUNmvx2e2n4WWWCd+ppBaAy0V8fXQGHUAUCVlkjYJU1XF+00n9TaLJFpEVVwCZAQMBKazT81BrlSSIyZ2mkqlKNjH0tDK/26qZf3hvVCQCw/3cfAMClBBcsnNkWb73QBdOiO0EQgDlL46FQWFamsLTz+oF4nf2DzZo1C2+99Rb++OOPWntzf39/fPDBB2jevDlEUcTq1avRv39/nDhxAm3atKm196lNA0fmYFusO3asdwcALJ7kj0d7FCJ8SC42fOYtcXSmY2n13pPc2OD1kgOheDn4LIJ9M+HlVAI/lyK8GPsiSsptAADvbX8Kf476BqEBaTiU6g9Xu5to7FaAGXHdcCHHAwCwcP9jGNz+LJp75Br0ANQnSjfD1nfeai2s/QH7hyvX5yzUwPVlK7gPvf3VYNP4dvmSfToISsDzXSUEReU+XlOUSBlSgfJUETYB5tG6L8y3MXj9wtAkXE+1x+n4ygbLto0B+m1Z6fZY83lzLF1/AF5+N5FxrX7+29aEpZ3XdH9VTvaiWPmTpmvXrrX25n379jV4PXfuXCxbtgyHDh2ql8leaa1D8+BSrPvMS79OFAWc2OeMoI71tzVnLEuvt0LQoVfzy7BXVuBUujcCVIUQAZRrrfRl1FoldKKADg3TcSjVH/lldkjOdUXf1heQkOWJcq0VXmx3DjdK7HEuy1O6ylSDWCGi8Dct3CKsIAgCNLkiys6IcO4tIPWNclSkibAJFODxthL2IYq/9wEEJfSJHgAE27+790/qYBNgdc/3qs+USh26P5uOTf9rDODuHyu2dho83S8NGdfskZNhOTcOs/Tz+l54U50q+ren3RlLq9Xi+++/R0lJCcLCwu5ZRq1WQ61W618XFhaaLJ57cXHXwkoJ5Gcb/tnycpQIaKa+z17mz1Lr3dzjBv738k+wUWpRWmGNsVt7IynXHXk37XGzwhrjuhzE4j9DIQAY2+UQlAoRno63vgQFjPipLz7tuw2Hor6GThSQW2qPtzb1QaHaVspqVVnxbh10xYDLc5UJuiKt8pvsxlcaNBithG1LAUW/6JD2dgUarbOGTSMF7DsJyF4I5H2rgetgK+huAjc+q+zC1+SY5zfhY92z4OSkwe9b/AzW93kxBcNGX4C9gxapVxzxXlQnaDS1dodxyVnqef2vZHzpXbWSfYsWLR6Y8HNzc6sVwOnTpxEWFoaysjI4OTlh48aNCAoKumfZmJgYzJo1q1rHJ7qf5DxXvLD2JTjbluPp5pfxfq9dGPZDfyTluuO/v/TCtKf2IiLkNHSigN8Sm+NcZgPo9Ce7iPe670NuqT0iNwyAWqPEwLYJ+Kzfbxj83SDklDr+21vXC4WbtXAMU0Dp+fc5rav8j+p5K6j6Vf4AsGupQOlRHQo369AgWgHbhxTwnqlEzkINcpZqISgA1ctWsHJHLT5po2716n8Nxw40QG6OYav9j998ceKQB9waqDHotSuY8sEpTHjjUVSUm1/vBVG1kv2sWbPuuoOesVq2bImTJ0+ioKAAP/zwAyIjI7Fnz557JvwpU6Zg/Pjx+teFhYUICAi4q5ypFOZaQasBXD0NJyO5NdAgL7vWHjNQ71hqvTU6K6QWVH6ez2V5oq13Fl7tcBqzd3bFwZQAPLsqAq52N6EVFShS2+KPEatw7ULl1SahAWl4sslVdF7+hn5cf+4fnghrdA39gxKx4tjDktWrKirSRZQeEeE7/3biUjaoTPo2TQx/0Ns0FqDJuN2kceltBZfeVtDcEKGwByAA+bFaWDc0j/H6O3n63ETIozcwb2KHu7aVFlujtNga11MdkXjaFet378Lj3bOwZ7uvBJHWPks9r/+NnLvxq/VbfPDgwYiMjPzXpbpsbGzQrFkzdOzYETExMWjfvj0+/fTTe5a1tbXVz9y/tdQlTYUCF/9yQIcuRfp1giAipEsxzsVbzqSdf5JLvQVBhI2V1mBdfpk9itS2eNT/GtwdbmJ3UmMAgJ2y8gtSJxomOJ1YeZz6rnCLFlZugGPn218BSj/AyhOouGoYf0WKCKXv3Ylc6SFA4SCgKE4HwQZwCDW/pv3T/dJQkGeDI/sb/HtBAYAgwtpGVydx1QW5nNcGJJyN/8EHH0AQBIwdO1a/rqysDFFRUfDw8ICTkxMGDRqEzMxMg/1SUlLQp08fODg4wMvLCxMnToRGU/2rX6r8882U4/V30ul0BuPy9c1PXzbAhEWpuHDKAYknHPD8iGzYOeiwY5271KGZlKXVe0znQ9h/pRHSi5zgaF2BZ1tdxCP+1/HWxucAAAOCziMp1xW5N+0R4puJSV3349vj7XElr3K29ql0bxSqbTG3104sP9wJao0Sg9qeg7+qCHuTA6Ws2gOJOhGFW7Rw6WMFQXnHRDtBgNurVsj9UgubFgJsWyhQtFWL8qsifD683QOQv0ELu2ABCnug9LCInMUaNIi2gpWzebXsBUHE0/3SsHNrQ+i0t3+o+DQsxRO9MnDioAcK8m3QwKsMLw5NRnmZFY4+6EeBmbG087q+Onr0KL744gsEBwcbrB83bhx++eUXfP/991CpVIiOjsbAgQPx559/Aqicy9anTx/4+PjgwIEDSE9Px+uvvw5ra2vMmzevWjFUezZ+bZoyZQqeeeYZNGrUCEVFRYiNjcXu3buxffv2Wn+v2rJnsxtUHlq8PjEDbp4aJJ21x3sRTZCfYy11aCZlafV2t7+JueG74OlQgqJyG1zM8cBbG5/DwZTKYaHGbvkY0/kQVHZqpBU646sjHbHmxO0TNb/MHm9t7IPRnY9gxaDNUCp0uJzrjtFbeuNCTv1OCKVHRGgyAJd+d7fE3V5RQiwHchZooC0EbJsLaPiZNWz8byfysrM63PhSB7EUsG4swOv/lHB51vzGsUNCb8DLtww7fja8CVK5WoE2IXnoP+QqnFwqkH/DFmdOuGHCG6EoyDOPyZdVZWnn9QNJMEGvuLgYERER+Oqrr/D+++/r1xcUFGDFihWIjY3FU089BQBYuXIlWrdujUOHDuGxxx7Djh07cO7cOfz+++/w9vZGSEgI5syZg0mTJmHmzJmwsbG539veRRBNkcWraPjw4di5cyfS09OhUqkQHByMSZMm4emnn67S/oWFhVCpVOiG/lAKFvrhJL3r7z4udQiS6PpivNQhSCK5n/wetqVJz5A6hDqnESuwGz+joKDAZEOzt3JFy3HzYGVb88snteoyJC78P6SmphrEamtrC1vbe/8QjIyMhLu7OxYuXIhu3bohJCQEixYtwq5du9CjRw/k5eXB1dVVXz4wMBBjx47FuHHjMH36dGzevBknT57Ub09OTkbTpk1x/PhxdOhw91yT+5F0FsaKFSukfHsiIpKTWmrZ/3Ni+IwZMzBz5sy7iq9btw7Hjx/H0aNH79qWkZEBGxsbg0QPAN7e3sjIyNCX8fb2vmv7rW3VYZlTLomIiEzkXi37e5UZM2YM4uLiYGcn/c2YzG/6LBERUU3U0mz8f14Vdq9kHx8fj6ysLDz88MNQKpVQKpXYs2cPFi9eDKVSCW9vb5SXl9/1yPjMzEz4+FQ+o8HHx+eu2fm3Xt8qU1VM9kREJAt1+Tz7Hj164PTp0zh58qR+6dSpEyIiIvT/b21tjZ07d+r3SUxMREpKiv4usmFhYTh9+jSysrL0ZeLi4uDi4nLfm8/dD7vxiYiIapmzszPatm1rsM7R0REeHh769cOHD8f48ePh7u4OFxcXvPPOOwgLC8Njjz0GAOjVqxeCgoLw2muvYf78+cjIyMDUqVMRFRV13wmB98NkT0RE8lDP7o2/cOFCKBQKDBo0CGq1GuHh4fj888/1262srLB161aMGjUKYWFhcHR0RGRkJGbPnl3t92KyJyIiWZD6drm7d+82eG1nZ4elS5di6dKl990nMDAQv/76q3FvDI7ZExERWTy27ImISB7qWTd+XWKyJyIieZBxsmc3PhERkYVjy56IiGRB+HsxZn9zxWRPRETyIONufCZ7IiKSBakvvZMSx+yJiIgsHFv2REQkD+zGJyIikgEzTtjGYDc+ERGRhWPLnoiIZEHOE/SY7ImISB5kPGbPbnwiIiILx5Y9ERHJArvxiYiILB278YmIiMhSsWVPRESywG58IjMQsOK81CFI4kjmw1KHIIkGLtlSh1D30qUOwMLJuBufyZ6IiORBxsmeY/ZEREQWji17IiKSBY7ZExERWTp24xMREZGlYsueiIhkQRBFCGLNm+fG7Cs1JnsiIpIHduMTERGRpWLLnoiIZIGz8YmIiCwdu/GJiIjIUrFlT0REssBufCIiIksn4258JnsiIpIFObfsOWZPRERk4diyJyIieWA3PhERkeUz5654Y7Abn4iIyMKxZU9ERPIgipWLMfubKSZ7IiKSBc7GJyIiIovFlj0REckDZ+MTERFZNkFXuRizv7liNz4REZGFY8u+BvoOzcELo7Lg7qlB0jl7fD61IRJPOkgdlslZcr0jRiUj4u0rButSkx3wn36hAIDo6Yno8Fgu3D3LUVZqhXOnVFi5sCmuJTtKEG3NDQo9i4GhZ+HrVgQASM5yx9c7O+LghUYAABulBmOePYhe7S/B2kqLQxcDMP/nJ5BbbPjv3Ofh83ily19o1KAAJWpr7Dz9ED7a/ESd16eq2gZnY9DLF9CsRT48GpRhztTHcPDPhvrtjz+Rhmf7JqFZi3y4qMoR/WYPJF121W/38i7BqnXb7nnseTNDsX+Pv6mrYDKWfF7fhd34VFVd++Vh5IzrWDLZH+ePO+D5EdmYG5uE4U+0RMENa6nDMxk51PvKRUe8N6K9/rVWK+j//9I5Z+z+xRtZ6bZwVmkQMSoZ739xCm/0DoNOJ9zrcPVSZoEjlm4PRWqOCoIA9Hk4ER+/tg2vLXkBSVnuGNfnADq3SsGUtb1QXGaDif3348OI7RjxxfP6Y7zS5RRe6XIKS34Lw5lUL9jbaPQ/HuorOzstki+7YsdvjTFtzqF7bNfg7JkG2LfbH2MmHr9re062AyIG9jFY17tvMga9fAHHDvuYLG5Tk8N5fSfOxq8HPvjgAwiCgLFjx0odyr8aODIH22LdsWO9O1Iu2mHxJH+obwoIH5IrdWgmJYd6a7UC8m7Y6pfCfBv9tm0/+OFMvCuyrtvjcoIz1nzWFF6+anj5lUkYcfXtP98YBxIDkXrDFSk5rli2IxSl5dZo2ygTjrZq9Ot0Hot+CcOxpIY4f90Ts3/ohvaNM9E2IBMA4GynxltPH8Ws75/C9lPNkZarwqUMD+xLaCxtxR7g2BEfrPmmDQ7ub3jP7bviAvHdmtY4Ee91z+06nYC8PDuD5fEuadi32x9lZebbZpLDeW3g1nX2xixmql4k+6NHj+KLL75AcHCw1KH8K6W1Ds2DS3F8n7N+nSgKOLHPGUEdSyWMzLTkUu+GjUrx7c4/seK3g5j4wTl4+tw7kdvaa/H0gHSkX7NDToZtHUdZexSCDk8HX4K9TQVOp3ijdcMcWCt1OHLpdpf01Ww3pOc5oV2jDABAaPNUCIIIT5cSrB+3Dlsmf4t5Q3bAS1UsVTUk0axFHh5qXoAdvzaWOpQak8t5TZUk/0laXFyMiIgIfPXVV3j//ff/taxarYZarda/LiwsNHV4BlzctbBSAvnZhn+2vBwlApqp77OX+ZNDvRNPu2DBtNa4dsUB7g3UeGXUFXy0+jhGPf8obpZW1rvPy2l4Y/xl2DtokZrsgPdGhECjqRe/l6vlIe8bWDFqI2yUWtwst8a7/wtHcpY7WvheRLlGgeIywx8wucX28HC+CQDwcy+CQhAxtNsJLNjaGcVlNnir1xF89sZWvLL4RWi0VlJUqc71evYKUq44I+Gsh9Sh1Jgczut/Yje+hKKiotCnTx/07NnzgWVjYmKgUqn0S0BAQB1ESHJwbL8H9u/wwpULTjh+wAMz3g6Go7MGT4Rn6cv88Ys33nmxE94d2gFpV+wx5ZMzsLbRShh1zVzNccWrS17EG58PxI+H22DGC3+giVfVum0VgghrpQ6fbO2MQxcDcCbVG1PX9URAgwJ0anrdxJHXDzY2WnTrkYrtZtyqly2xFhYzJWnLft26dTh+/DiOHj1apfJTpkzB+PHj9a8LCwvrNOEX5lpBqwFcPTUG690aaJCXLXknicnIsd4lRdZIu+oAv0Y39etKi5UoLVbieooDzp9ywYY/9+HxHjnY85u3hJFWn0ZrhWs3VACA89c9EeSfhZcfP43f/2oGG6UOTnZqg9a9u9NN3CiyBwDkFFXO0k7OdNNvzy+xR36JHbxd6/ckvdrSpes12NpqsHNHoNShGEWO57WcSdayT01NxZgxY7B27VrY2dlVaR9bW1u4uLgYLHVJU6HAxb8c0KHL7S81QRAR0qUY5+It9FIVyLPedvYa+AbcRG72fcbkhcrF2saM77LxN4UgwkapRUJaA1RoFHjkoTT9tkYN8uHrVozTKZUzzv+6WvnfQM98fRkX+zK4OpYhI98ZctDr2Ss4fMAPhQXmO18DkOd5fasb35jFXEn28y0+Ph5ZWVl4+OGH9eu0Wi327t2Lzz77DGq1GlZW9W/876cvG2DColRcOOWAxBOVl6rYOeiwY5271KGZlKXXe/h/L+HwHg9kXbeDh2c5Xo1Khk4rYPdvXvDxv4knw7Nw/KA7CnKt0cBbjReHX0W5WoGj+8xrzPbt8MM4mBiAjHwnONhWIDzkEh5uch2jV/ZBidoWm4+1wtg+B1B40xYlZTaY0G8//rrqjTOplb0XKTmu2HO2McY/9yfmbeyKErUNosIP42q2K45d9pO4dvdnZ6eBX8Pbkwi9fUvR9KF8FBXZIDvLAU7O5fDyKoV7g8qeHP9GlQkwL7dy5v0tvn7FaBucgxmTO9dtBUzE0s/ru/Cpd3WvR48eOH36tMG6YcOGoVWrVpg0aVK9TPQAsGezG1QeWrw+MQNunhoknbXHexFNkJ9jedek3snS693AW41JH56Di2sFCvJscPa4CuMiOqIwzwZKpRptOuaj/2upcHLRIP+GDc7Eu+K/r3VEQa7Ngw9ej7g73sSMl3ahgXMpistscCnDA6NX9sGRS5XDYQt/eRw6UcAHETtgo9Ti0IXKm+rcaeb3T2FcnwNYOPRXiKKA40l+GL2yD7S6+nnOAkDzlnn4cNFe/euRUX8BAOK2BWLhh53w2OPXMX5yvH775OlHAABrV7XG2tVB+vW9nr2CnGx7HD9mXkM392Pp5zXdJohi/fmp0q1bN4SEhGDRokVVKl9YWAiVSoVu6A+lwA+npbPysNDWxgPkPNdS6hAk0eBQttQh1Dlt4iWpQ6hzGrECu/EzCgoKTDY0eytXhD0zG0rrqg0b34umogwHf5tu0lhNhbMwiIhIHni73Pph9+7dUodARERkcepVsiciIjIVOd9Uh8meiIjkQSdWLsbsb6aY7ImISB5kPGYv+e1yiYiIyLTYsiciIlkQYOSYfa1FUveY7ImISB5kfAc9duMTERFZOCZ7IiKShbp+EE5MTAweeeQRODs7w8vLCwMGDEBiYqJBmbKyMkRFRcHDwwNOTk4YNGgQMjMzDcqkpKSgT58+cHBwgJeXFyZOnAiNxvBphQ/CZE9ERPJQx8+z37NnD6KionDo0CHExcWhoqICvXr1QklJib7MuHHjsGXLFnz//ffYs2cPrl+/joEDB+q3a7Va9OnTB+Xl5Thw4ABWr16NVatWYfr06dWKhWP2REREJrBt2zaD16tWrYKXlxfi4+Px5JNPoqCgACtWrEBsbCyeeuopAMDKlSvRunVrHDp0CI899hh27NiBc+fO4ffff4e3tzdCQkIwZ84cTJo0CTNnzoSNTdUexsWWPRERyYIgikYvQOWDde5c1Gp1ld6/oKAAAODuXvlQr/j4eFRUVKBnz576Mq1atUKjRo1w8OBBAMDBgwfRrl07eHvfftJieHg4CgsLcfbs2SrXncmeiIjkQVcLC4CAgACoVCr9EhMT8+C31ukwduxYdO7cGW3btgUAZGRkwMbGBq6urgZlvb29kZGRoS9zZ6K/tf3WtqpiNz4REVE1pKamGjzi1tbW9oH7REVF4cyZM9i/f78pQ7svJnsiIpKFO7via7o/ALi4uFTrefbR0dHYunUr9u7dC39/f/16Hx8flJeXIz8/36B1n5mZCR8fH32ZI0eOGBzv1mz9W2Wqgt34REQkD3U8G18URURHR2Pjxo3YtWsXmjRpYrC9Y8eOsLa2xs6dO/XrEhMTkZKSgrCwMABAWFgYTp8+jaysLH2ZuLg4uLi4ICgoqMqxsGVPRETyUMd30IuKikJsbCx+/vlnODs768fYVSoV7O3toVKpMHz4cIwfPx7u7u5wcXHBO++8g7CwMDz22GMAgF69eiEoKAivvfYa5s+fj4yMDEydOhVRUVFVGj64hcmeiIjIBJYtWwYA6Natm8H6lStXYujQoQCAhQsXQqFQYNCgQVCr1QgPD8fnn3+uL2tlZYWtW7di1KhRCAsLg6OjIyIjIzF79uxqxcJkT0REslCTu+D9c//qEKvQE2BnZ4elS5di6dKl9y0TGBiIX3/9tXpv/g9M9kREJA98EA4RERFZKrbsiYhIFgRd5WLM/uaKyZ6IiOSB3fhERERkqdiyJ7OhvZErdQiS8PjpjNQhSEJXVrWHixBVWQ1ujHPX/maKyZ6IiGShtm6Xa47YjU9ERGTh2LInIiJ5kPEEPSZ7IiKSBxH6Z9LXeH8zxWRPRESywDF7IiIislhs2RMRkTyIMHLMvtYiqXNM9kREJA8ynqDHbnwiIiILx5Y9ERHJgw6AYOT+ZorJnoiIZIGz8YmIiMhisWVPRETyIOMJekz2REQkDzJO9uzGJyIisnBs2RMRkTzIuGXPZE9ERPLAS++IiIgsGy+9IyIiIovFlj0REckDx+yJiIgsnE4EBCMSts58kz278YmIiCwcW/ZERCQP7MYnIiKydEYme5hvsmc3PhERkYVjy74G+g7NwQujsuDuqUHSOXt8PrUhEk86SB2Wycmt3s+9noM+r9+Ad0A5AOBqoh3WLvTGsT9cJI6s9vQZko4+Q9Lh3VANALh60QGxnwfg2F53fZlWIYWIHHcVrYKLoNMJuJzgiKnD26BcbSVV2EZr+2gRXvhPOpq3K4WHdwVmjWiGgzvcDMoENLuJ4ZOvoV1oEayUIlIu2mHOW82Qfd1WoqhNQ1bntYy78SVt2c+cOROCIBgsrVq1kjKkB+raLw8jZ1zH2gU+iApvgaRzdpgbmwSVR4XUoZmUHOudnW6Nb+b5Irp3C7zzTAuc+tMJM1deQWCLMqlDqzU5GTZY+XFjvDMwBKMHheDUIRWmL01Ao2YlACoT/ftfn8Xx/a4Y82J7jH6hPbas9YWoM+Y2ZNKzc9AiOcEBS6cF3nO7b6MyfPJDAlIv2+HdwS0xKrwNYhf7oVxtWZ2hsjuvdaLxi5mSvGXfpk0b/P777/rXSqXkIf2rgSNzsC3WHTvWV7Z8Fk/yx6M9ChE+JBcbPvOWODrTkWO9D8epDF6v+tAXz71+A606luDqBTuJoqpdh//wMHi9elFj9BmSgVYhRUi55Ij/TEnGz9/64fuvAvRl0pLNv9V3bLcrju12ve/2yIlpOPqHK1bE3K53eopl/JvfSY7ntVxJ/jNVqVTCx8dHvzRo0EDqkO5Laa1D8+BSHN/nrF8nigJO7HNGUMdSCSMzLbnW+04KhYiu/fNg66BDwjFHqcMxCYVCRNdns2HnoMX5Ey5QuZejVUgRCm5Y45PvTiH2z8OY/+1faNOxQOpQTUoQRDz6VD7Sku0wd00i1sWfwKJN5xDWK0/q0GqVLM9rUWf8YqYkT/YXL16En58fmjZtioiICKSkpNy3rFqtRmFhocFSl1zctbBSAvnZhr0PeTlKuHlq6jSWuiTXegNA41Y3seniaWy98hdGf3ANs4c3RspFy2rhNW5Rgp+OH8Dm038ietYlzIlqjZTLDvANqByuiIhOwbbvfTDtzTa4dM4JMavOwC/wpsRRm45rAw0cnHR4aVQ6ju1R4f9ea4kD290w7YtLaBdat985piTL8/rWmL0xi5mSNNmHhoZi1apV2LZtG5YtW4bk5GQ88cQTKCoqumf5mJgYqFQq/RIQEHDPckS15dplW7z9dAuM7tMcW9c0wIRPU9CoueWM2QPAtWR7RA3ogLEvheCX73zx3w8voNFDpRD+/nb4db0P4n7yxuUEJ3wZ0xTXku3Ra1CmtEGbkPD3HdYOxrli4wofJJ1zwIZlvjiy0xV9IrIljo6MIuMxe0mT/TPPPIMXX3wRwcHBCA8Px6+//or8/Hxs2LDhnuWnTJmCgoIC/ZKamlqn8RbmWkGrAVz/8avXrYEGedn1e66BMeRabwDQVChw/YotLp12wMoYXySfs8eANy3rC19ToUB6ij0unXXCqgWNkXTeEf1fv47cbBsAQMplwzH6lMsO8PJTSxFqnSjMU0JTISDlor3B+pRLdvBsWC5RVLVPzue1HEnejX8nV1dXtGjRApcuXbrndltbW7i4uBgsdUlTocDFvxzQocvtngdBEBHSpRjn4s1/0tL9yLXe9yIIgLWN+f66rwpBAVjb6JB5zRY5mTbwb2LYZe/f+CYy0yzr8rM7aSoUuPCXA/ybGvbgNGxShqw0G4miqn2yPK/ZjV8/FBcX4/Lly/D19ZU6lPv66csGeOaVXPR8MRcBzcrwzgfXYOegw4517g/e2YzJsd7DpqSjbWgxvP3L0bjVTQybko7gx4vxx0a3B+9sJoaOv4K2nQrg1bAMjVuUYOj4Kwh+tAB/bPEEIODHFQ3R/7Xr6BKeA99GN/HamKvwb3oTO34w75nadg5aNA0qRdOgyoloPgFqNA0qheffPRY/fOGLJ5/LRe/B2fANLEPfyEw81jMfW9d4SRl2rZPdeS3CyGQvdQVqTtK+mgkTJqBv374IDAzE9evXMWPGDFhZWWHIkCFShvWv9mx2g8pDi9cnZsDNU4Oks/Z4L6IJ8nOspQ7NpORYb9cGGkxcnAJ3Lw1Ki6yQnGCH915piuN7nR+8s5lw9ajAhA8vwN2rHCVFSiQnOmDq8DY4caDyB82m1Q1hbaPDyClJcFZpkHTeEe+90QbpqfYPOHL91iK4BPPXJ+pf/2d65ZBg3Pce+GRCUxzY7oYl7wXi5bfTMWrWVVy7XHlDnbPHLOffHpDneS1XgihK1y8xePBg7N27Fzdu3ICnpye6dOmCuXPn4qGHHqrS/oWFhVCpVOiG/lAK/HCSZVI4W1aCqSqxzHLnBdyPWGE5cwKqSiNWYDd+RkFBgcmGZm/lip4+I6FU1HwoRqMrx+8ZX5o0VlORtGW/bt06Kd+eiIjkRKcDYMS18jpeZ09ERET1FK+vICIieZDxg3CY7ImISB5knOzZjU9ERGTh2LInIiJ50Ikw6mJ5M75dLpM9ERHJgijqIBrx5Dpj9pUakz0REcmDaOTDbDhmT0RERPUVW/ZERCQPopFj9mbcsmeyJyIiedDpAMGIcXczHrNnNz4REZGFY8ueiIjkgd34RERElk3U6SAa0Y1vzpfesRufiIjIwrFlT0RE8sBufCIiIgunEwFBnsme3fhEREQWji17IiKSB1EEYMx19ubbsmeyJyIiWRB1IkQjuvFFJnsiIqJ6TtTBuJY9L70jIiKie1i6dCkaN24MOzs7hIaG4siRI3UeA5M9ERHJgqgTjV6qa/369Rg/fjxmzJiB48ePo3379ggPD0dWVpYJanh/TPZERCQPos74pZoWLFiAESNGYNiwYQgKCsLy5cvh4OCAb775xgQVvD+zHrO/NVlCgwqj7pNAVJ8pxHKpQ5CEKFZIHUKdk2OdNaisc11MfjM2V9yKtbCw0GC9ra0tbG1t7ypfXl6O+Ph4TJkyRb9OoVCgZ8+eOHjwYM0DqQGzTvZFRUUAgP34VeJIiEyoSOoAiEyvqKgIKpXKJMe2sbGBj48P9mcYnyucnJwQEBBgsG7GjBmYOXPmXWVzcnKg1Wrh7e1tsN7b2xvnz583OpbqMOtk7+fnh9TUVDg7O0MQhDp978LCQgQEBCA1NRUuLi51+t5SkmO95VhnQJ71lmOdAWnrLYoiioqK4OfnZ7L3sLOzQ3JyMsrLje8lE0Xxrnxzr1Z9fWPWyV6hUMDf31/SGFxcXGT1pXCLHOstxzoD8qy3HOsMSFdvU7Xo72RnZwc7OzuTv8+dGjRoACsrK2RmZhqsz8zMhI+PT53Gwgl6REREJmBjY4OOHTti586d+nU6nQ47d+5EWFhYncZi1i17IiKi+mz8+PGIjIxEp06d8Oijj2LRokUoKSnBsGHD6jQOJvsasrW1xYwZM8xirKY2ybHecqwzIM96y7HOgHzrXRdefvllZGdnY/r06cjIyEBISAi2bdt216Q9UxNEc77ZLxERET0Qx+yJiIgsHJM9ERGRhWOyJyIisnBM9kRERBaOyb4G6sPjCuva3r170bdvX/j5+UEQBGzatEnqkEwuJiYGjzzyCJydneHl5YUBAwYgMTFR6rBMatmyZQgODtbfXCUsLAy//fab1GHVuQ8++ACCIGDs2LFSh2JSM2fOhCAIBkurVq2kDotMgMm+murL4wrrWklJCdq3b4+lS5dKHUqd2bNnD6KionDo0CHExcWhoqICvXr1QklJidShmYy/vz8++OADxMfH49ixY3jqqafQv39/nD17VurQ6szRo0fxxRdfIDg4WOpQ6kSbNm2Qnp6uX/bv3y91SGQKIlXLo48+KkZFRelfa7Va0c/PT4yJiZEwqroFQNy4caPUYdS5rKwsEYC4Z88eqUOpU25ubuLXX38tdRh1oqioSGzevLkYFxcndu3aVRwzZozUIZnUjBkzxPbt20sdBtUBtuyr4dbjCnv27KlfJ9XjCqnuFRQUAADc3d0ljqRuaLVarFu3DiUlJXV+a0+pREVFoU+fPgbnuKW7ePEi/Pz80LRpU0RERCAlJUXqkMgEeAe9aqhPjyukuqXT6TB27Fh07twZbdu2lTockzp9+jTCwsJQVlYGJycnbNy4EUFBQVKHZXLr1q3D8ePHcfToUalDqTOhoaFYtWoVWrZsifT0dMyaNQtPPPEEzpw5A2dnZ6nDo1rEZE9UBVFRUThz5owsxjNbtmyJkydPoqCgAD/88AMiIyOxZ88ei074qampGDNmDOLi4ur8yWhSeuaZZ/T/HxwcjNDQUAQGBmLDhg0YPny4hJFRbWOyr4b69LhCqjvR0dHYunUr9u7dK/kjleuCjY0NmjVrBgDo2LEjjh49ik8//RRffPGFxJGZTnx8PLKysvDwww/r12m1WuzduxefffYZ1Go1rKysJIywbri6uqJFixa4dOmS1KFQLeOYfTXUp8cVkumJoojo6Ghs3LgRu3btQpMmTaQOSRI6nQ5qtVrqMEyqR48eOH36NE6ePKlfOnXqhIiICJw8eVIWiR4AiouLcfnyZfj6+kodCtUytuyrqb48rrCuFRcXG/zaT05OxsmTJ+Hu7o5GjRpJGJnpREVFITY2Fj///DOcnZ2RkZEBAFCpVLC3t5c4OtOYMmUKnnnmGTRq1AhFRUWIjY3F7t27sX37dqlDMylnZ+e75mI4OjrCw8PDoudoTJgwAX379kVgYCCuX7+OGTNmwMrKCkOGDJE6NKplTPbVVF8eV1jXjh07hu7du+tfjx8/HgAQGRmJVatWSRSVaS1btgwA0K1bN4P1K1euxNChQ+s+oDqQlZWF119/Henp6VCpVAgODsb27dvx9NNPSx0amcC1a9cwZMgQ3LhxA56enujSpQsOHToET09PqUOjWsZH3BIREVk4jtkTERFZOCZ7IiIiC8dkT0REZOGY7ImIiCwckz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMZaejQoRgwYID+dbdu3TB27Ng6j2P37t0QBAH5+fn3LSMIAjZt2lTlY86cORMhISFGxXXlyhUIgoCTJ08adRwiqjkme7JIQ4cOhSAIEARB/xS32bNnQ6PRmPy9f/rpJ8yZM6dKZauSoImIjMV745PF6t27N1auXAm1Wo1ff/0VUVFRsLa2xpQpU+4qW15eDhsbm1p5X3d391o5DhFRbWHLniyWra0tfHx8EBgYiFGjRqFnz57YvHkzgNtd73PnzoWfnx9atmwJAEhNTcVLL70EV1dXuLu7o3///rhy5Yr+mFqtFuPHj4erqys8PDzw7rvv4p+Pl/hnN75arcakSZMQEBAAW1tbNGvWDCtWrMCVK1f0Dxdyc3ODIAj6B+zodDrExMSgSZMmsLe3R/v27fHDDz8YvM+vv/6KFi1awN7eHt27dzeIs6omTZqEFi1awMHBAU2bNsW0adNQUVFxV7kvvvgCAQEBcHBwwEsvvYSCggKD7V9//TVat24NOzs7tGrVCp9//nm1YyEi02GyJ9mwt7dHeXm5/vXOnTuRmJiIuLg4bN26FRUVFQgPD4ezszP27duHP//8E05OTujdu7d+v08++QSrVq3CN998g/379yM3NxcbN2781/d9/fXX8d1332Hx4sVISEjAF198AScnJwQEBODHH38EACQmJiI9PR2ffvopACAmJgZr1qzB8uXLcfbsWYwbNw6vvvoq9uzZA6DyR8nAgQPRt29fnDx5Em+++SYmT55c7b+Js7MzVq1ahXPnzuHTTz/FV199hYULFxqUuXTpEjZs2IAtW7Zg27ZtOHHiBN5++2399rVr12L69OmYO3cuEhISMG/ePEybNg2rV6+udjxEZCIikQWKjIwU+/fvL4qiKOp0OjEuLk60tbUVJ0yYoN/u7e0tqtVq/T7ffvut2LJlS1Gn0+nXqdVq0d7eXty+fbsoiqLo6+srzp8/X7+9oqJC9Pf317+XKIpi165dxTFjxoiiKIqJiYkiADEuLu6ecf7xxx8iADEvL0+/rqysTHRwcBAPHDhgUHb48OHikCFDRFEUxSlTpohBQUEG2ydNmnTXsf4JgLhx48b7bv/oo4/Ejh076l/PmDFDtLKyEq9du6Zf99tvv4kKhUJMT08XRVEUH3roITE2NtbgOHPmzBHDwsJEURTF5ORkEYB44sSJ+74vEZkWx+zJYm3duhVOTk6oqKiATqfDK6+8gpkzZ+q3t2vXzmCc/tSpU7h06RKcnZ0NjlNWVobLly+joKAA6enpCA0N1W9TKpXo1KnTXV35t5w8eRJWVlbo2rVrleO+dOkSSktL73qGfHl5OTp06AAASEhIMIgDAMLCwqr8HresX78eixcvxuXLl1FcXAyNRgMXFxeDMo0aNULDhg0N3ken0yExMRHOzs64fPkyhg8fjhEjRujLaDQaqFSqasdDRKbBZE8Wq3v37li2bBlsbGzg5+cHpdLw4+7o6Gjwuri4GB07dsTatWvvOpanp2eNYrC3t6/2PsXFxQCAX375xSDJApXzEGrLwYMHERERgVmzZiE8PBwqlQrr1q3DJ598Uu1Yv/rqq7t+fFhZWdVarERkHCZ7sliOjo5o1qxZlcs//PDDWL9+Pby8vO5q3d7i6+uLw4cP48knnwRQ2YKNj4/Hww8/fM/y7dq1g06nw549e9CzZ8+7tt/qWdBqtfp1QUFBsLW1RUpKyn17BFq3bq2fbHjLoUOHHlzJOxw4cACBgYF477339OuuXr16V7mUlBRcv34dfn5++vdRKBRo2bIlvL294efnh6SkJERERFTr/Ymo7nCCHtHfIiIi0KBBA/Tv3x/79u1DcnIydu/ejdGjR+PatWsAgDFjxuCDDz7Apk2bcP78ebz99tv/eo1848aNERkZiTfeeAObNm3SH3PDhg0AgMDAQAiCgK1btyI7OxvFxcVwdnbGhAkTMG7cOKxevRqXL1/G8ePHsWTJEv2kt7feegsXL17ExIkTkZiYiNjYWKxatapa9W3evDlSUlKwbt06XL58GYsXL77nZEM7OztERkbi1KlT2LdvH0aPHo2XXnoJPj4+AIBZs2YhJiYGixcvxoULF3D69GmsXLkSCxYsqFY8RGQ6TPZEf3NwcMDevXvRqFEjDBw4EK1bt8bw4cNRVlamb+n/97//xWuvvYbIyEiEhYXB2dkZzz///L8ed9myZXjhhRfw9ttvo1WrVhgxYgRKSkoAAA0bNsSsWbMwefJkeHt7Izo6GgAwZ84cTJs2DTExMWjdujV69+6NX375BU2aNAFQOY7+448/YtOmTWjfvj2WL1+OefPmVau+/fr1w7hx4xAdHY2QkBAcOHAA06ZNu6tcs2bNMHDgQDz77LPo1asXgoODDS6te/PNN/H1119j5cqVaNeuHbp27YpVq1bpYyUi6Qni/WYWERERkUVgy56IiMjCMdkTERFZOCZ7IiIiC8dkT0REZOGY7ImIiCwckz0REZGFY7InIiKycEz2REREFo7JnoiIyMIx2RMREVk4JnsiIiIL9/+PB+TCwoNgQQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 640x480 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "old_pred=evaluate(X,y,old)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "b590d8c8-f1b8-47a8-adf7-15c26429759c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(new_pred!=old_pred).sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "855953bd-93e5-4a1c-8a2d-5da225615f5d",
+   "metadata": {},
+   "source": [
+    "# Performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "33c217e4-d001-4f55-81c9-8b9e1599dd9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timeit\n",
+    "M = pd.concat([X]*10, ignore_index=True)\n",
+    "d = {\n",
+    "    'type':[],\n",
+    "    'time':[],\n",
+    "    'size':[]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "2319afe2-50bf-471e-b34a-cf42c5453ce9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1\n",
+      "Epoch 2\n",
+      "Epoch 3\n",
+      "Epoch 4\n",
+      "Epoch 5\n",
+      "Epoch 6\n",
+      "Epoch 7\n",
+      "Epoch 8\n",
+      "Epoch 9\n",
+      "Epoch 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(1,11):\n",
+    "    M = pd.concat([X]*i, ignore_index=True)\n",
+    "    t = timeit.timeit('new.predict(M)', globals=globals(), number=100)\n",
+    "    d['type'].append('new')\n",
+    "    d['time'].append(t)\n",
+    "    d['size'].append(i)\n",
+    "    print('Epoch', i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "6b763c74-96c9-43fe-9f72-999a5d578f33",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1\n",
+      "Epoch 2\n",
+      "Epoch 3\n",
+      "Epoch 4\n",
+      "Epoch 5\n",
+      "Epoch 6\n",
+      "Epoch 7\n",
+      "Epoch 8\n",
+      "Epoch 9\n",
+      "Epoch 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(1,11):\n",
+    "    M = pd.concat([X]*i, ignore_index=True)\n",
+    "    t = timeit.timeit('old.predict(M)', globals=globals(), number=100)\n",
+    "    d['type'].append('old')\n",
+    "    d['time'].append(t)\n",
+    "    d['size'].append(i)\n",
+    "    print('Epoch', i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "d3c80230-db88-4c77-a399-d9d11efdc9e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot: xlabel='size', ylabel='time'>"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAGwCAYAAABcnuQpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy89olMNAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB4AElEQVR4nO3dd3hU1dbH8e/MpHcS0kkgEHoJoTfpAhEBBUGQKmJHxC6v/VpQr128YEGqgog0UUF6JxAg9E4agRAgkF5n5v3jJIFIMSGZOTOT9XmeeTyZdn4hyKzss/deGqPRaEQIIYQQwkpp1Q4ghBBCCFEZUswIIYQQwqpJMSOEEEIIqybFjBBCCCGsmhQzQgghhLBqUswIIYQQwqpJMSOEEEIIq2andgBTMxgMnDt3Dnd3dzQajdpxhBBCCFEORqORzMxMgoKC0GpvP/Zi88XMuXPnCAkJUTuGEEIIIe5AUlIStWrVuu1zbL6YcXd3B5Q/DA8PD5XTCCGEEKI8MjIyCAkJKf0cvx2bL2ZKLi15eHhIMSOEEEJYmfJMEZEJwEIIIYSwalLMCCGEEMKqSTEjhBBCCKtm83Nmykuv11NYWKh2DKtgb2+PTqdTO4YQQggBSDGD0WgkJSWFq1evqh3Fqnh5eREQECB79wghhFBdtS9mSgoZPz8/XFxc5MP5XxiNRnJyckhNTQUgMDBQ5URCCCGqu2pdzOj1+tJCxsfHR+04VsPZ2RmA1NRU/Pz85JKTEEIIVVXrCcAlc2RcXFxUTmJ9Sv7MZJ6REEIItVXrYqaEXFqqOPkzE0IIYSmkmBFCCCGEVZNiRgghhBBWTYoZIYQQQlg1KWbMoHv37kyePFntGEIIIUTVKiqAU2vVTiHFjBBCCCHu0LYvYP4QWPm8qjGkmDGxcePGsWnTJr788ks0Gg0ajQY7Ozs++eSTMs+LjY1Fo9Fw6tQpQFktNH36dKKionB2dqZu3bosXry4zGuSkpIYNmwYXl5eeHt7M2jQIOLj4831rQkhhKjOUo/Cpo+V49qdVI0ixYyJffnll3Ts2JFHH32U8+fPc/78ed555x1mzZpV5nmzZs2ia9euhIeHl973xhtvMGTIEPbv38/IkSMZPnw4R48eBZT9Xfr27Yu7uztbtmxh27ZtuLm50a9fPwoKCsz6PQohhKhmDHpYPhEMhdAgCpoNUTWOqsXM5s2bGTBgAEFBQWg0GpYtW3bL5z7xxBNoNBq++OILs+WrCp6enjg4OODi4kJAQAABAQE8/PDDHD9+nF27dgFKYfLzzz8zfvz4Mq8dOnQoEyZMoEGDBrz77ru0adOGr7/+GoBffvkFg8HADz/8QPPmzWncuDGzZs0iMTGRjRs3mvvbFEIIUZ1Ez4DkGHD0gP6fgsp7j6lazGRnZxMREcE333xz2+ctXbqUnTt3EhQUZKZkphUUFET//v358ccfAfj999/Jz89n6NChZZ7XsWPHG74uGZnZv38/p06dwt3dHTc3N9zc3PD29iYvL4/Tp0+b5xsRQghR/aTFwbp3leO7/wOewermQeXeTFFRUURFRd32OcnJyTzzzDOsXr2a/v37mymZ6U2YMIHRo0fz+eefM2vWLB588MEKtVXIysqidevW/PTTTzc85uvrW5VRhRBCCIXRCL9PgqJcqHMXtB6ndiLAwhtNGgwGRo8ezUsvvUTTpk3L9Zr8/Hzy8/NLv87IyDBVvHJzcHBAr9eXue+ee+7B1dWV6dOns2rVKjZv3nzD63bu3MmYMWPKfB0ZGQlAq1at+OWXX/Dz88PDw8O034AQQggBsHcuxG0GO2cY+JXql5dKWPQE4I8++gg7OzsmTZpU7tdMnToVT0/P0ltISIgJE5ZPnTp1iI6OJj4+nkuXLmEwGNDpdIwbN44pU6ZQv379Gy4pAfz666/8+OOPnDhxgrfeeotdu3YxceJEAEaOHEnNmjUZNGgQW7ZsIS4ujo0bNzJp0iTOnj1r7m9RCCGErcs4B3+/rhz3fB2866qb5zoWW8zs2bOHL7/8ktmzZ1eoqeGUKVNIT08vvSUlJZkwZfm8+OKL6HQ6mjRpgq+vL4mJiQA88sgjFBQU8PDDD9/0de+88w4LFy6kRYsWzJ07lwULFtCkSRNA6Vq9efNmQkNDGTx4MI0bN+aRRx4hLy9PRmqEEEJULaMR/ngB8jMguDV0eFLtRGVY7GWmLVu2kJqaSmhoaOl9er2eF154gS+++OKW+6k4Ojri6OhoppTl06BBA3bs2HHD/cnJydjb25e5lHS9oKAg/v7771u+b0BAAHPmzKmynEIIIcRNHV4Cx/8ErT0MnAZandqJyrDYYmb06NH07t27zH19+/Zl9OjRtxzJsBb5+flcvHiRt99+m6FDh+Lv7692JCGEEOLmsi/Dny8rx11fBP8m6ua5CVWLmaysrNIdbwHi4uKIjY3F29ub0NBQfHx8yjzf3t6egIAAGjZsaO6oVWrBggU88sgjtGzZkrlz56odRwghhLi1Va9CziXwawJd1G1bcCuqFjMxMTH06NGj9Ovnn1f+kMaOHcvs2bNVSmV648aNY9y4cbd9jtFoNE8YIYQQ4lZOrIaDi0CjVS4v2TmoneimVC1munfvXqEPbek7JIQQQphJXgasfE457vAU1Gqtbp7bsNjVTEIIIYRQ0dq3ICMZaoRBj9fUTnNbUswIIYQQoqz4rRCjtNxh4FfgUP4d6tUgxYwQQgghrinIgRXPKMetx0FYV1XjlIcUM0IIIYS4ZuNUSDsD7kFKI0krIMWMEEIIIRTJe2DHNOX43s/AyVPdPOUkxYwQQgghoKgAlj8DRgM0ewAaRqmdqNykmBFCCCEEbPsCUg+Diw9EfaR2mgqRYsZKde/enUmTJvHyyy/j7e1NQEAAb7/9dunjV69eZcKECfj6+uLh4UHPnj3Zv38/AOnp6eh0OmJiYgAwGAx4e3vToUOH0tfPnz/fIjqOCyGEMIPUo7DpY+U46mNwralungqy2N5MajEajeQW6s1+Xmd7XYW6gwPMmTOH559/nujoaHbs2MG4cePo3Lkzd999N0OHDsXZ2Zm//voLT09Pvv32W3r16sWJEyfw9vamZcuWbNy4kTZt2nDw4EE0Gg379u0jKysLNzc3Nm3aRLdu3Uz03QohhLAYBj0snwiGQmgQBc2GqJ2owqSY+YfcQj1N3lxt9vMe+U9fXBwq9uNo0aIFb731FgD169dn2rRprFu3DmdnZ3bt2kVqamppB/FPPvmEZcuWsXjxYh577DG6d+/Oxo0befHFF9m4cSN33303x44dY+vWrfTr14+NGzfy8ssvV/n3KYQQwsJEz4DkGHD0gP6fQgV/sbYEUsxYsRYtWpT5OjAwkNTUVPbv309WVtYNjTpzc3M5ffo0AN26dWPmzJno9Xo2bdpEnz59CAgIYOPGjbRo0YJTp07RvXt3c30rQggh1JAWB+veVY7v/g94Bqub5w5JMfMPzvY6jvynryrnrSh7e/syX2s0GgwGA1lZWQQGBrJx48YbXuPl5QVA165dyczMZO/evWzevJkPPviAgIAAPvzwQyIiIggKCqJ+/fp38q0IIYSwBkYj/D4JinKhzl3KBnlWSoqZf9BoNBW+3GNpWrVqRUpKCnZ2dtSpU+emz/Hy8qJFixZMmzYNe3t7GjVqhJ+fHw8++CArV66U+TJCCGHr9s6FuM1g56y0LLDCy0slZDWTDerduzcdO3bkvvvu4++//yY+Pp7t27fz2muvla5gAmVF1E8//VRauHh7e9O4cWN++eUXKWaEEMKWZZyDv19Xjnu+Dt511c1TSVLM2CCNRsOff/5J165defjhh2nQoAHDhw8nISEBf3//0ud169YNvV5fZm5M9+7db7hPCCGEDTEa4Y8XID8DgltDhyfVTlRpGqPRaFQ7hCllZGTg6elJeno6Hh4eZR7Ly8sjLi6OsLAwnJycVEponeTPTgghrNSh32DxeNDaw+Obwb+J2olu6naf3/8kIzNCCCFEdZF9Gf4s3naj64sWW8hUlBQzQgghRHWx6lXIuQR+TaDL82qnqTJSzAghhBDVwYnVcHARaLQwcBrYOaidqMpIMSOEEELYurwMWPmcctzhKajVWt08VUyKGSGEEMLWrX0LMpKhRhj0eE3tNFVOihkhhBDClsVvhZgfleOBX4GDi7p5TECKGSGEEMJWFeTAimeU49bjIKyrqnFMRYoZIYQQwlZtnAppZ8A9SGkkaaOkmBFCCCFsUfIe2DFNOb73c3DyVDePCUkxY4M2btyIRqPh6tWrt3zO7NmzSztoCyGEsDFFBbD8GTAaoPlQaNhP7UQmJcWMEEIIYWu2fg6ph8HFB/p9qHYak5NiRgghhLAlqUdh83+V46iPwbWmunnMQIoZK5Wfn8+kSZPw8/PDycmJLl26sHv37ls+f/bs2YSGhuLi4sL999/P5cuXzZhWCCGEWRj0sHwiGAqhQRQ0G6J2IrOwUzuAxTEaoTDH/Oe1dwGNptxPf/nll/ntt9+YM2cOtWvX5uOPP6Zv376cOnXqhudGR0fzyCOPMHXqVO677z5WrVrFW2+9VZXphRBCWILoGZAcA44ecO9nFfpcsWZSzPxTYQ58EGT+8/7fOXBwLddTs7OzmT59OrNnzyYqKgqA77//njVr1jBz5kzatm1b5vlffvkl/fr14+WXlU6pDRo0YPv27axatapqvwchhBDqSYuDde8qx33eBQ8VPstUIpeZrNDp06cpLCykc+fOpffZ29vTrl07jh49esPzjx49Svv27cvc17FjR5PnFEIIYSZGI/w+CYpyoc5d0Gqs2onMSkZm/sneRRklUeO8QgghxJ3YOxfiNoOds9KyoJpcXiohxcw/aTTlvtyjlnr16uHg4MC2bduoXbs2AIWFhezevZvJkyff8PzGjRsTHR1d5r6dO3eaI6oQQghTyzgHf7+uHPd8HbzrqptHBVLMWCFXV1eefPJJXnrpJby9vQkNDeXjjz8mJyeHRx55hP3795d5/qRJk+jcuTOffPIJgwYNYvXq1TJfRgghbIHRCH+8APkZENwaOjypdiJVyJwZK/Xhhx8yZMgQRo8eTatWrTh16hSrV6+mRo0aNzy3Q4cOfP/993z55ZdERETw999/8/rrr6uQWgghRJU6vASO/wlaexg4DbQ6tROpQmM0Go1qhzCljIwMPD09SU9Px8PDo8xjeXl5xMXFERYWhpOTk0oJrZP82QkhhMqyL8M37SDnEnSfAt1fVTtRlbrd5/c/qToys3nzZgYMGEBQUBAajYZly5aVefztt9+mUaNGuLq6UqNGDXr37n3D3A8hhBCiWlr1qlLI+DWBLs+rnUZVqhYz2dnZRERE8M0339z08QYNGjBt2jQOHjzI1q1bqVOnDn369OHixYtmTiqEEEJYkBOr4eAi0GiVy0t2DmonUpWqE4CjoqJKN327mYceeqjM15999hkzZ87kwIED9OrV66avyc/PJz8/v/TrjIyMqgkrhBBCWIK8DFj5nHLc4Smo1VrdPBbAaiYAFxQU8N133+Hp6UlERMQtnzd16lQ8PT1LbyEhIWZMKYQQQpjY2rcgIxlqhEGP19ROYxEsvphZuXIlbm5uODk58fnnn7NmzRpq1rx1B9ApU6aQnp5eektKSvrXc9j4HGiTkD8zIYRQQdwWiPlROR74FTjIhqtgBcVMjx49iI2NZfv27fTr149hw4aRmpp6y+c7Ojri4eFR5nYr9vb2AOTkqNBY0sqV/JmV/BkKIYQwsYIcpWUBQOtxENZV1TiWxOI3zXN1dSU8PJzw8HA6dOhA/fr1mTlzJlOmTKn0e+t0Ory8vEqLIxcXFzTVbAvoijIajeTk5JCamoqXlxc6XfXc00AIIcxu41RIOwPuQXD3f9ROY1Esvpj5J4PBUGaCb2UFBAQA3Ha0R9zIy8ur9M9OCCGEiSXvgR3TlON7PwcnT3XzWBhVi5msrCxOnTpV+nVcXByxsbF4e3vj4+PD+++/z8CBAwkMDOTSpUt88803JCcnM3To0CrLoNFoCAwMxM/Pj8LCwip7X1tmb28vIzJCWJHUjDx+3BZPZl4hb9zbBCd7+f/XqhQVwPJnwGiA5kOhYT+1E1kcVYuZmJgYevToUfr1888rm/6MHTuWGTNmcOzYMebMmcOlS5fw8fGhbdu2bNmyhaZNm1Z5Fp1OJx/QQgibcvZKDt9uOsMvMUkUFBkAaBLkwcj2tVVOJipk6+eQehhcfKDfh2qnsUjVup2BEELYojMXs5i+8TRL9yVTZFD+iQ/0dOJ8eh71/dz4+7muMj/QWqQehRl3gaEQhsyE5g+onchsKvL5bXVzZoQQQtzc0fMZfLPhFH8ePE9xDUOX8Jo83SOcpsEedPxgHSdTs9h++jKdw2+9xYWwEAY9LJ+oFDINoqDZELUTWSwpZoQQwsrFJl1l2vpTrD16ofS+3o39eLpHOJGhNUrve6B1LebsSGDWtngpZqxB9AxIjgFHD7j3M5DRtFuSYkYIIayQ0WgkOi6NbzacYsvJS4DyWXdP80Ce7h5Ok6Abh+XHdKrDnB0JrDt2gcTLOYT6yIZrFistDta9qxz3eRc8gtTNY+GkmBFCCCtiNBrZdOIi09afIibhCgA6rYb7I4N5sns96vm63fK19Xzd6NbAl00nLjJ3Rzyv39vEXLGrzuGlcOBXCGwBoR0guA043vp7tlQbj6cyd0cCr/RrRMMA97IPGo3K5nhFuVDnLmg1Vp2QVkSKGSGEsAIGg5G/j1zgmw2nOJicDoCDTsuwtrV4vGs9QrzLN8oyrnMdNp24yC8xSTx3dwNcHa3oYyDtDCx9UvmQP/6Hcp9GV1zYdISQ9sp/3f3VzfkvivQG3lh+iKS0XA6cTWfxEx2pU9P12hP2zoW4zWDnrLQskMtL/8qK/hYLIUT1U6Q38MfB83yz4RQnLmQB4GyvY2T7UB7tWhd/D6cKvV+3+r6E1XQl7lI2S/YlM7qDlSzTNhrh92eVQiYoEnzCIXEnpCfBuX3Kbef/lOfWCFOKmtAOyq1mA4sqCFYfvkBSWi4Al7LyGflDNIuf7EigpzNknIO/X1ee2PN18K6rYlLrIcWMEEJYoIIiA0v2nmX6ptMkXFZ6obk72jG2Ux3GdwnD29Xhjt5Xq9UwpmNt3vn9CHO2xzOqfah1LNPeN//aaMUDP177kL+aBEnRSmGTuBMuHIIrccpt/8/Kc5y9rxU2oR0hMALsHFX5NoxGI99tOQPAqA6hbDt1mbhL2Yz6IZpFj3XA548XID8DgltDhydVyWiNZJ8ZIYSwIHmFehbuSuS7zWc4l54HQA0Xex7pEsbojnXwdK58c9fMvEI6fLCO7AI98x9pT5f6Fr6yKfMCfNMW8tLh7neh86RbPzcvHZJ2Q+IOpcg5G6OM5lxP56gUCyXFTUg7cPYy6bdQYnd8GkNn7MDBTsv2V3uSX2TggenbOZ+ex5M19/NK1kegtYfHN4O/Fc5pqkKyz4wQQliZrPwi5u9M4IctcVzKUvrP+bk78ljXujzUPhQXh6r759rdyZ6hbUKYvT2e2dvjLL+Y+etlpUgJjIAOT93+uU6eUL+3cgOlFUDKAaW4Sdyp/DfnMiRuV24AaMCvCYS2v3Z5yjPEJJemvtusjMoMaVWLmm7K6NC8R9rz+IzVPJI5HTRQ2Pl57Kt5IVNRUswIIYSKruYUMHt7PLO2xZOeq/SHC/Zy5snu9XigdS2T9VEa07E2s7fHs+5YKgmXs6nt4/rvL1LDsT/gyDJlou/AaaCr4MeWnQPUaqPcOj2jzL25fLpscZN2WmkXkHoYYn5UXucRrBQ1IcWXp/ybgrZyP4vTF7NK9wKacFdY6f3hfm78Vvd3vE5lcMwQwicJ3fhfkQEHO22lzledSDEjhBAquJiZzw9bzzB/RwLZBXoA6tZ05ake4QxqGYS9zrQfZHV93eje0JeNxy8yd0cCb1jiMu28dPjjBeW48yRl1VJlaTRQM1y5tRqt3JeVet28mx1wfj9kJMOh35QbgIO7cjkqtKMyghPcBhwqtk/PzK1xGI3KhoZlltCfWI3XqaUYNVreMD7O7hNXeeHX/XzxYEt0WiuYz2QBpJgRQggzOnc1l+82n2HBrkTyi5s/NgpwZ2LPcKKaBZr1w2tcpzpsPH6RRbuTeN4Sl2mveQsyz4N3Pej2iunO4+YHjQcoN4CCbEjeA4nRxXNvdkFBJpxep9wAtHbKZa+Sy1IhHcDN95anuJyVz297zgLw6F3XrVDKy4CVzwGg6fAUT9d5kEfnxvD7/nO4O9nx/n3NrGOCtsos7G+uEELYpoTL2UzfeJrf9p6lUK+su2gZ4sUzPcPp2chPlQ+srvV9qVvTlTOXslmy9yyjO9Yxe4Zbit8Ge2YpxwO/Antn853bwRXCuio3UHokXTh8beQmcSdknlMKnuQ9sGOa8jzvetctCe8IPvVK593M25lAfpGBiFqetAvzvnautW8po0A1wqDHa3R3cOGLByN5ZsFefo5OxMPJnlejGpnve7dSUswIIYQJnbiQyf82nGLF/nOlzR871PXmmZ716VTPR9XfurVaDWM71eGtFYeZvT2eke1ro7WEyxqFecoOuKDsfluni7p5tMUb8wW2gPaPKfNu0pPKFjepR5W5N2mnIXa+8jqXmhDagcLgduzdboc9tXi0a91rP/O4Ldfm6Az8qvSyVf8WgWTmNefVJQeZsek0Hs52PNU9XIVv3HrI0mwhhDCBQ8npTFt/ilWHU0rv697Ql4k9wmlTx/s2rzSvrPwiOnywjqz8IuaOb0fXBre+VGI26/4DWz4FtwB4Otpsy6YrJffKtSXhiTuVERt9fpmn5OGAQ+12aEM7KLsVr3pF2dW49TgY8OUNb/n95jO8/+dRAN67rxmjrGWDwyoiS7OFEEIlMfFpfL3+FJtOXCy9L6pZAE/3CKdZsKeKyW7OzdGOoW1qMWtbPLO3x6tfzKQchG3FH+z9P7GOQgbAuQY06KPcAIry4VwshsSd7NiwkiZFR6ihyYKErcqthHsQ3P2fm77lo13rkp5byLQNp3hj+SHcnewY1DLYDN+M9ZFiRgghKsloNLLt1GW+Xn+S6Lg0ALQaGNQymKe616O+v/u/vIO6xnasw+zt8aw/lkrcpWzCaqq0TNughxXPgKGo7IRca2TnCKHtWZtZm8eyw/F00rLj0VBcUnZfm1icmQKDvlb2xrmFF/o0ICOvkLk7Enhh0X7cHO3o1diye0+pQYoZIYS4Q0ajkbVHU5m24RT7k64CYK/T8EDrWjzRrZ7l7t3yD3VqutK9gS8bjivdtN8a0FSdIDunKz2WHD0h6r/qZKhi3xe3LnioQxguwY0guKlyWQmUuTf/MmdKo9Hw9oCmZOYVsXRfMk/9tJfZD7ejYz0fEye3LlLMCCFEBekNRv4sbv54LCUTAEc7LSPahfJY17oEeZlx5U0VGdc5jA3HL/JrzFle6NMQN3Mv006Lg/XvKcd93gWPQPOe3wT2JV5hd/wV7HUaxnWqc+MTyjn5W6vV8PEDLcjMK2Lt0QtMmLObBY91oEUtryrNa81ke0EhhCinQr2BX2OSuPuzTTyzYB/HUjJxddDxRLd6bH2lJ28PbGqVhQzAXeE1qevrSlZ+EUv2njXvyY1GWDlZ6aFU5y5oNca85zeRH7bEAcrlxop2N/8ne52WaQ9F0rGuD9kFesb+uIuTFzKrIqZNkGJGCCH+RV6hnnk7E+j+3428tPgAZy5l4+lsz3O9G7D91V68GtUIX3d1ujBXFa322ujB7O3xGAxmXOi6fwGc2Qh2TsqqHhvYJC7xcg5/HToP/GOTvEpwstfx/dg2RIR4cSWnkFEzo0lKy6mS97Z2UswIIcRtrNh/jq4fb+CNZYdIvppLTTdHpkQ1YturPXm2d308XSrfxdpSDG5VC3dHO85czGbLqUvmOWlWKqyaohx3f1XZaM4G/LgtDoMRujXwpWFA1U0Ad3O0Y87DbWng78aFjHxGzYwmNSOvyt7fWkkxI4QQt5Camcfzv8SSmplPkKcT7wxsytZXevB4t3rmn1NiBsoy7RAAZm+LM89J/3oF8q5CQHPoONE85zSxqzkF/LI7Cai6UZnrebk4MO+R9oR6u5BwOYfRM3dxNaegys9jTaSYEUKIW1i85yxFBiMRtTzZ+FIPxnaqY7Iu1pZiTMfaaDSw4fhF4i5lm/Zkx/+Cw0uu64htG6NcP0Unkluop3GgB53DTbPqyN/DiZ8mtMfP3ZHjFzIZN2s32flFJjmXNZBiRgghbsJgMJb+dj2yQ20c7KrHP5d1arrSs6EfAHO2x5vuRHkZ1zpid3waglqa7lxmlF+kZ3bxn9tjXcNM2q4ixNuF+RPa4+ViT2zSVR6bF0Neod5k57Nk1eP/TiGEqKAdZy6TcDkHd0c77m1h/cuEK2Jc5zqAMjKVmVdompOse+dag8XuU0xzDhUsjz3Hxcx8AjycuLdFkMnP18DfnTkPt8PVQce2U5d5ZsE+ivQGk5/X0kgxI4QQN7FgVyIAgyKDcHGwvfkxt9MlvCbhfm5k5Rfx2x4TLNNO3Am7f1COB3xZ2mDR2hmNRr7frGySN75LHex15vmIjQjx4oexbXGw07LmyAVeXnzAvKvRLIAUM0II8Q+Xs/JZXdwgcnjbUJXTmJ9Go3TTBpizI6FqPxgL85SWBQCRo6But6p7b5VtPHGRk6lZuDnaMbydef/edKznw/8eaoVOq2HJvmT+s/IINt5HugwpZoQQ4h+W7E2mUG+kebCnRTaHNIfBkcG4O9kRdymbTScv/vsLymvLp3DpBLj6QZ/3qu59LUDJqMzwtiF4OJl/MnPvJv58NiwCjUbZK+jzNSfMnkEtUswIIcR1jEYjC3Yrl5hGtA2Blc/DT0MhJ03lZObl6mjHsNJl2vFV86YXDsPWz5Tje/6rdJq2EYeS09l++jI6rYaHu4SplmNQy2D+M6gZAF+tP8UPxb2hbJ0UM0IIcZ1dcWmcuZiNi4OO+z2OQcxMOPk3zB8MeelqxzOrkmXam05c5PTFrMq92fUdsRv2hyaDqiakhShpKHlvi0CCVW5pMbpDbV7q2xCA9/44yi/Fxbktk2JGCCGus7B4OfagFgE4b3732gPn9sFPw6DAxHuvWJDaPq70aqQs0563I6Fyb7brO0jeA44e0P8Tm2hZUOLc1VxWHqja1gWV9VT3ejzeVckyZclB/jx4XuVEpiXFjBBCFLuaU8Afxf/oP17zAKQcVD58Ry8DJ09I2gkLhkNhrrpBzWhcJ+WSya8xSXe+TPtKAqz7j3J89zvgYfoly+Y0a1sceoORTvV8LGaOlUaj4dWoRoxoF4LBCM8u3MemE1U498nCSDEjhBDFlu5LpqDIQLMAF2rvL57b0WkS1OsBo5aAgxvEbYZFY6Coemwf3znch3A/N7IL9Cy+k2XaRiOsfA4Kc6B2Z2g1rsozqikjr5AFu0zXuqAyNBoN793XnHtbBFKoN/L4vBh2x9vm3C8pZoQQguKJv8V7y7wetBvNlThlxU2HJ5Un1GoDDy0CO2dlDs1v40Fv+9vHazTXumnPuZNu2gcWwel1oHNU9pTR2tbHzsJdiWTlF1Hfz41uDXzVjnMDnVbDZ8Na0r2hL3mFBsbP3s3hc7Y398u2/lYJIcQd2pt4lRMXsvCyL6RdwvfKnd1eBke3a0+q0xlG/Aw6Bzj6Oyx7QpnYauMGt1KWacdfzqnYpYrsS7DqVeW428tQs75pAqqkoMjAj1vjAWVURqu1zHlADnZapo9sTbs63mTmFTFm5i7OVHZCt4WRYkYIIbi24+/7gdvQZqeCV21oNfbGJ9brCcPmgtYODv4KKyeDwba3j3dxsGN4W2WZ9qyK9Gta9SrkpoF/M+j8rGnCqeiPg+dIycijppsjgyItex6Qs4OOH8a1oVmwB5ezCxj1QzTJV21n7peqxczmzZsZMGAAQUFBaDQali1bVvpYYWEhr7zyCs2bN8fV1ZWgoCDGjBnDuXPn1AsshLBJGXmFrDxwDk+y6HtlgXJnz9fBzuHmL2gYBUN+AI0W9s5VPrRtfLfVMR3roNHA5hMXOZVajt/qT6xWij2NFgZ+bTMdsUsorQviAHi4cx0c7Sy/m7qHkz1zHm5HPV9XzqXnMfqHaC5l5asdq0qoWsxkZ2cTERHBN998c8NjOTk57N27lzfeeIO9e/eyZMkSjh8/zsCBA1VIKoSwZcv3JZNXaOD/PFZhV5ipjCQ0e+D2L2p6Pwz6n3K861tY+5ZNFzQh3i70buwPwNwd8bd/cn6mstkgQIenILiVacOpYPvpyxw5n4GzvY6R7a2n5YWPmyPzJ7Qn2MuZM5eyGTNzF+m5Jmomakaqdk+LiooiKirqpo95enqyZs2aMvdNmzaNdu3akZiYSGjozf/y5Ofnk59/rdLMyMiousBCCJujTPxNwp80hhT9odzZ683yTVRtOQKKcpXVOtu+BHtX6P6KaQOr6OFOdVhz5AKL95zlxb4Nb71l/7p3IeOscqmux/+ZN6SZfFfcumBYm1p4udxiBM9CBXo6M39Ce4bO2MGR8xk8Mns38x5pj7OD5Y8u3YpVzZlJT09Ho9Hg5eV1y+dMnToVT0/P0ltISIj5AgohrM7B5HSOnM/gOYel2BnyIbQj1O9T/jdoMx76TlWON34A274yTVAL0LGeDw383cgp0PNrzC2WaSftUjbIg+KO2K7mC2gmx1My2XTiIloNjFexdUFlhNV0Zd4j7fBwsiMm4QqPz99DQZH1zv2ymmImLy+PV155hREjRuDh4XHL502ZMoX09PTSW1JSkhlTCiGszYJdiYRpzjNUu0G5o9dbFd+dtuNT0PMN5XjNG7Dr+6oNaSHKdNPeHo/+n8u0i/Jh+UTACC1HKvvz2KCS1gX9mgVQ28d6i7XGgR7MergdzvY6Np+4yORf9t34M7USVlHMFBYWMmzYMIxGI9OnT7/tcx0dHfHw8ChzE0KIm8nKL2JF7DlesPsVHQZo0A9qd7yzN+v6Itz1onL854uwb37VBbUg90cG4+FkR2JaDhuPp5Z9cMtncOk4uPraXEfsEhcy8lgemwxY3iZ5d6J17Rp8N6Y1Djotfx5M4f+WHMRohXO/LL6YKSlkEhISWLNmjRQnQogq8/v+c4QVnuRe3U6MaJS5MpXR83Xo8LRyvHwiHFxc+ZAWxsXBjuHtlDmLs69fpp16FLZ8qhxHfQwu3uYPZwZztsdTqDfStk4NIkNto+v3XfV9+WpES7Qa+CUmiff/OGp1BY1FFzMlhczJkydZu3YtPj4+akcSQtiQhbsSednuFwA0LR4E/6aVe0ONBvq+r8yjwQhLHlM217MxozvURquBLScvcSo187qO2IXQIEpZ6WWDsvOLmL9TabhpC6My1+vXLJCPhrQA4IetcUxbf0rlRBWjajGTlZVFbGwssbGxAMTFxREbG0tiYiKFhYU88MADxMTE8NNPP6HX60lJSSElJYWCgurRE0UIYTqHz6Xjem4bXXUHMWrtoceUqnljjQbu+RQiRoBRD78+DCfXVs17W4jrl2nP2Z4Au3+As7vBwR36f2pTHbGvtygmiYy8IsJqupZ+/7ZkaJsQ3ry3CQCfrjnBnIpskKgyVYuZmJgYIiMjiYyMBOD5558nMjKSN998k+TkZFasWMHZs2dp2bIlgYGBpbft27erGVsIYQMWRifyst1CADRtxkONOlX35lotDJymjFAYCuGXkUqDShsyrnMdALbvjcW49h3lzrvfBs9g1TKZUpHewMytyiZ5j3QJs9jWBZU1vksYk3srbSfeWnGY3+6kuagKVN1npnv37re9Lmdt1+yEENYhp6CIzNiltNSeQW/ngq7ri1V/Ep0dDP5eWeFz/E/4eTiMXgqh7av+XCroWNeHhn5uvHLlYzSF2RDSAVqPVzuWyaw6nMLZK7l4uzowpFUtteOY1LO96pORW8SP2+J4+bcDuDvZ0adpgNqxbsui58wIIYQp/BmbxESj0rZA2/FpcPMzzYl09vDALKWfU2E2/PQAnNtnmnOZmUaj4a2wI/TUxVKAHfoBX9lcR+wSSusCZTn26A61rXpzufLQaDS83r8xD7Suhd5gZOLP+9h26pLasW7LNv/mCSHEbVzYOptw7Tly7TzRdJ5k2pPZO8GDP0HtzpCfAfPuhwuHTXtOc8i+TMcT/wXgq8L72XDJS908JrQ7/gr7z6bjaKdldMfaascxC61Ww4eDm9OvaQAFegOPzo1hX+IVtWPdkhQzQohq5WRyKvenzwWgqPPz4GSG7R4cXOChXyC4DeRegbmD4NJJ05/XlFZPQZN7mVTnenyrH1B2mbaNKWldMKR1LWq6OaqcxnzsdFq+HNGSu+rXJKdAz7hZuzmWYpktgqSYEUJUK3F/fUmQJo00Oz/cuzxhvhM7usOo3yCgBWRfhDkDIS3OfOevSifXwoFfAA3GgV+j19ix9dQlTl7IVDtZlTt9MYu1Ry8AysTf6sbRTse3o1vTKtSL9NxCRs/cRcLlbLVj3UCKGSFEtZGXeYV2Z2cDcKH1c8olIHNy9oLRy8C3EWSeg7kDId06VouUys9SGmsCdHgS/8ad6dNEmRxqi6MzP2xRCs7ejf2p5+umchp1uDjYMWtcOxoFuHMxM5+RP0STkp6ndqwypJgRQlQbCb9/iBdZxGlq0eDuR9UJ4eoDY5aDdz24mqiM0GReUCfLnVj/HqQngmco9HgNoLRf05K9yaTnFKoYrmpdysrnt71KsflYV9vaJK+iPF3smfdIe+r4uHD2Si6jZ0aTlm05e75JMSOEqB6yUql9chYAhxs+i87OXr0s7gEwdoVSEKSdVubQZF9WL095nY2B6BnK8YDPwVEZqehQ15tGAe7kFur5dY/tNPeduyOBgiIDESFetK1jG60LKsPX3ZH5E9oT6OnEydQsxs3aRWaeZRSvUswIIaqF9NUf4GTMJ9ZQj9b9RqkdBzxrKQWNeyBcPArz7oPcq2qnurWiAqVlAUZoMRzCe5c+pNFoGFfSTXvHTbppW6HcAn1p64LH7qqLxkZ3Na6oWjVcmPdIe7xdHThwNp0Jc2LIK9SrHUuKGSFENZAWh9uheQD8HfgkgV4uKgcq5h0GY1YoXaZTDij70ORb6CTabV9A6hFwqQn9pt7w8KCWwXi52JOUlsv6Y6k3vt7K/Lb3LGnZBYR4O9O3qe21LqiMcD835o5vh7ujHdFxaTz9014K9QZVM0kxI4Swefr176MzFrFZ35xW3QaqHacs3wbKpGDnGkp/o5+HQ0GO2qnKungcNit7yhD10U07Yjs76BjetqSbtpWu0iqmNxhLWxeM7xyGnU4+Kv+pWbAnM8e1xdFOy7pjqUxZclDVPPITEkLYtpSDaA8tBuAHxzF0b+ircqCbCGgGo5aAowckbFV6ORXlq51KYTDAikmgL4D6faDZkFs+dXRHpZv2tlOXOWHFy7TXHr1A3KVsPJzsGNYmRO04FqtdmDczRrXGw8mOQS2DVM0ixYwQwratexcNRn7XdyCiXTfL/S07uBWMXAz2rnB6Pfw6DvQWMLkyZiYk7QQHN+j/2W07Ygd7OdO3qfUv0y5pXTCqQ21cHVVtYWjxejTyY8srPbmrvrq/JFjo/9VCCFEFErbDydUUGbV8ph9q+b9lh7aHEQvAzklpTrnkUTCoOLky/SyUdMTu9RZ4/fuf37jSZdpnrXKZ9p6EK8QkXMFed21Ss7g9T2cVVwYWk2JGCGGbjMbSD+Jf9D0ICW9BiLeFTPy9nbrd4MH5oLWHw0th+UTlUo+5GY3wxwtQkAm12kHbCeV6WbswbxoHepBXaOCXmEQTh6x6P2xRRmXuaxmMn4eZN1UUd0yKGSGEbTqxGpJ2kocDXxYN5qF2Fj4qc736d8PQWaDRwf6f4c8XlOLCnA4vgROrlKJq4Nfl7oit0Wh4uGSZ9vYEq1qmnXA5m9WHUwB4tJpvkmdtpJgRQtgegx7WKaMys4r6YnALoFdjK1te23gADP4O0EDMj7D6NfMVNDlp8OfLynHXF8GvUYVePrBlEDVc7Em+mlva18ga/Lg1DoMRujXwpYG/u9pxRAVIMSOEsD0HF0PqEbI1bkwvGsDQNrWwt9SJv7fT/AFlVARg5zew4X3znHf1a5BzCXwbQ5fnK/xyJ3sdI9oVL9PeFl/F4UzjSnYBi2KkdYG1ssL/u4UQ4jaK8mHDewB8XXgvGbgxvK0VXWL6p1ajIap4j5fN/4Utn5r2fKfXK5e20MDAr8DO4Y7eZlSH2ui0GnacucyxlIyqzWgCP0UnkFuop0mgB53q+agdR1SQFDNCCNuyZzZcTSTLviazi/rSOdyH2j6uaqeqnPaPwd3/UY7X/Qd2TjfNeQqy4fdnleN2j0FIuzt+qyCvazvnztmeUBXpTCavUM/s4oyPdZXWBdZIihkhhO3Iz4RNHwMwzTCEPBxLd6W1ep2fhe5TlONVr0LMrKo/x4YPlE7eniHQ641Kv924TmEALN13lqs5ltNh+Z+WxyZzKSufQE8n+rcIVDuOuANSzAghbMfO6ZBziRy32vyQ3RlvVwf62FJfnW6vKEUNwMrnYP/Cqnvv5D2w83/K8b2fg2PlJ8C2rVODJiXLtHdbZjdtg8HI91uutS6wyrlVQooZYUNSj0Ge5V+bFyaSfRm2fQXAPOdRFGHHkFbBONrpVA5WhTQa6P2OcgkIIyx7UtmLprL0hbD8GTAaoPkwZWl4FdBoNIzrXAeAuTsSKFK5GeHNbDpxkVOpWbg52vGgNS3fF2VIMSNsw6El8L/28E07pagR1c/Wz6Agk0K/5nx8tjEAD9rKJabraTTQ7yOIHK0UH79NgOOrKvee276E1MPg7H3TjtiVMTAiCG9Xh+Jl2pbXTfu74tYFI9qF4OGk/k624s5IMSOsX3oyrJysHGeeh1n94OweVSMJM7uaBLu+B+APv8fQG7W0C/Mm3M9N5WAmotXCgC+h+VAwFMGi0coqpDtx6WTpPCP6fQiuNasuJyXLtJURD0vrpn3wbDo7zlzGTqvh4c5hascRlSDFjLBuBgMsewLy0iEoEoLbQO4VmDMATm9QO50wl40fgj4fY+0u/PdkMEDpB6jN0urgvhnK5nr6AljwEMRvq9h7lHbEzofw3tBimEmilizT3nkmjaPnLedS8PfFrQvubRFIkJezymlEZUgxI6zbzv9B3Gawd4HBP8CY5VC3OxRmw8/D4MgKtRMKU0s9VrwvCuxt8CzJ6Xl4OtsT1awarErR2cGQH6F+HyjKVf7On40p/+v3zILE7Uqn7ns/v21H7MoI9HSmXzOlm/YcC+mmnXw1lz8Ongdgwl2ySZ61k2JGWK+UQ6Vb1tP3fagZDo5u8NAiaDxQ+W3117Gwd666OYVprX9XmTvS6F6+O+MNwP2RwTjZ29DE39uxc4BhcyGsKxRkwfzBcP7Av78u4xyseUs57vUmeJl2flFJv6al+5K5kq3+Mu1ZW+PQG4x0DvehWbCn2nFEJUkxI6xTYR4seVQpWBr0g9YPX3vMzhGGzr42QXLFM8oER2F7zsbAsZWg0XK5/cusK55gWrKVfrVh7wzDF0BIB+WS67z7bj8R/vqO2MFtoN2jJo/YunYNmgV7kF9kYKHKy7TTcwtZsEvp6C2jMrZBihlhnda/C6lHwNUXBk67cXhcq1N62pTsybHmTVj7tvk7DwvTMRqVnylAxEMsjHelyGCkVagXDQOqYZNARzcYuUiZO5ZzGeYOhMunb/7cI8vg+J/XdcQ2/SiWRqMp3URv3o54VZdpL9yVSHaBnvp+bnRv4KtaDlF1pJgR1ufMRtgxTTkeOA3cbvGPkUajbAHf+23l662fK6ueDHozhBQmd3o9xG8BnQOGbq+UbspW7UZlrufkCaOWgH8zyLoAcwYqO/peLycN/nxJOb7refBvYrZ497YIxMfVgXPpeaw5ok437YIiA7OKm18+Kq0LbIYUM8K65KTB0ieV4zbjoWG/f39Nl+eUZaxolL49i8dDkfrX7EUlGAzX5ku1fZTtl1xITMvB3dFOtqN38YbRy6BmA8g4q6zsyzh37fE1b0D2ReXxu14wa7Qy3bRVmgi88sA5UjLy8HV3ZFDLIFUyiKonxYywHkajsoV75jnwrgd93iv/a1uPg6GzlGH1I8tgwYNKUz1hnY4shfP7wcEd7nqBBbuV0Yf7IoNxcbBTOZwFcPNVVvbVqANX4mHuIMi6qIxq7puP0hH7a2V+mZmVLNOOjkvjyDnzLtM2Go2lm+SN61THtnaHruakmBHW48AvSiGi0cGQ78Ghgp2Qm94PD/2iLOM+vR7m3qeM9Ajroi+E9cWFbOdJXDa68ffhFACG2/reMhXhEQRjVoBHLbh0QpkUXNIRu+0ECO2gSqwATyeiVFqmve3UZY6lZOLioGNk+2p8OdIGSTEjrMOVhGvX+btPgeDWd/Y+4b2U31idvODsLpjdHzLOV1lMYQb75kHaGXCpCR2e4re9ZynUG2lRy5OmQbLEtowatWHsCnDzhwuHlFEaj2BlKbaKHi7u17QsNpk0My7T/q54k7xhbULwcnEw23mF6UkxIyyfQQ9Ln4D8DAhpr8yBqYyQdvDwX+AWoKyI+rGv8uEoLF9BDmz8SDnu9jJGB1cW7pKJv7flU08ZoXHxUb7u/xk4eagaqVVoDZoHexYv00789xdUgaPnM9h84iJajdIdW9gWKWaE5dv2pbJLqYMb3P+tsutpZfk3gUdWQ40wuJoAP/ZTNuETlm3Xt5CVomzw1noc0XFpnLmUjYuDjgERMpnzlvwawdO74Imt5Zs0b2LKMu06AMwzUzftH7YofaGimgUS6uNi8vMJ81K1mNm8eTMDBgwgKCgIjUbDsmXLyjy+ZMkS+vTpg4+PDxqNhtjYWFVyChWdi4UN7yvHUR+BdxX+RlWjDoxffW0Z6+x7IDG66t5fVK3cK8ryeoAer4GdIwuLNz4b1DIIN0eZ+HtbrjUhoLnaKUrdGxFITTcHzqfn8beJl2mnpOexYn8yABPuklEZW6RqMZOdnU1ERATffPPNLR/v0qULH330kZmTCYtQkKPs8msoUprptRxZ9edw94dxK5XLV3npyqqPk2ur/jyi8rZ9qfyM/JpA86FczSngz0PFE3/byiUma+Nop+OhkmXaxfu+mMrs7fEU6o20q+NNZGgNk55LqEPVX2WioqKIioq65eOjR48GID4+3kyJhEVZ+5ayCsMtAO790mRN8HCuAaOXwqIxcGotLBgOg7+FZkNMcz5RcRnnYecM5bjXm6DVsWRvIgVFBpoEetCilkz8tUYjO9TmfxtPsys+jUPJ6SbpkZSVX8TP0QmAskmesE02N2cmPz+fjIyMMjdhhU6ugV3fKcf3fQOuPqY9n4Or0tum6WAwFMLiRyDmR9OeU5Tfpo+UrtAhHaBBP4xGY2lvnRHtQmQXVyvl7+HEPc2VTQ5NtUx70e4kMvKKqFvTlV6N/ExyDqE+mytmpk6diqenZ+ktJET2nbA62Zdg+dPKcfsnILy3ec5r5wBDflB2FqZ4g74tn0o/J7VdPn2t83nvt0GjYW/iFU6mZuFkr2VQZLCq8UTljCtepr18/zkuZ+VX6XsX6Q3M3KpM/H3krjC0Wil6bZXNFTNTpkwhPT299JaUpG53VlFBRqOysVfWBfBtdK2vkrlodcrS1bteVL5e9x/4+3UpaNS0/j0w6qF+X6jdEYAFxcux720RhIeTvZrpRCVFhngRUcuTAhN00/7rUArJV3PxdnVgSKtaVfrewrLYXDHj6OiIh4dHmZuwIvvmwbGVStuBwd+BvbP5M2g00OsN6FO8imrHNFg+EfRF5s9S3Z2LhcNLAE3pRm/puYWsPKD0GpK9ZayfRqNhbPEy7fk7EyisomXa17cuGNOxNk720rrAltlcMSOsWNoZ+OtV5bjn6xAYoW6eThNh0Deg0ULsfPh1LBTmqZupuln3H+W/zYdCQDMAVsQmk1dooIG/G61CvdTLJqpM/xbXLdM+XDXLtKPj0jiYnI6jnZbRHWpXyXsKy6VqMZOVlUVsbGzp/jFxcXHExsaSmKhM7EtLSyM2NpYjR44AcPz4cWJjY0lJSVErsjAVfREseQwKs6F2F+j0jNqJFJGjYNg80DkoI0Y/D4X8TLVTVQ9xm+H0OtDaQY//A5Tftn8uvsQ0vG2oTPy1EY52Oh5qrxQcs7fHVcl7/lDcuuCB1rXwcTN/Q01hXqoWMzExMURGRhIZGQnA888/T2RkJG++qQwnr1ixgsjISPr37w/A8OHDiYyMZMaMGaplFiay5VM4uxscPeH+GcrcFUvR+F4YuVjZgThuM8wZCNmX1U5l24xGWPu2ctz64dLNEg+cTefo+Qwc7LQMbiUTf23JqPah2Gk17I6/wqHk9Eq916nULNYeTUWjgUe6yCZ51cEdFTOnT5/m9ddfZ8SIEaSmpgLw119/cfjw4Qq9T/fu3TEajTfcZs+eDcC4ceNu+vjbb799J7GFpToboyy9Bej/CXhZ4Aq0ut2Uhn3O3nBuL8yKgvRktVPZrmMrIXmP0uG860uld5csx76nWYA0CrQxfh5O9G+hLNOeXcll2jO3KqMyvRv7U9fXrbLRhBWocDGzadMmmjdvTnR0NEuWLCErKwuA/fv389Zbb1V5QGHj8rOUXX6NemWTuuZD1U50a8GtYfwqcA+CS8eVBpWXTqmdyvboi2Ddu8pxx6eVXZpRNj9bsV8m/tqykn5NK2LPcekOl2lfzMznt73KLxqPySZ51UaFi5lXX32V9957jzVr1uDgcO03o549e7Jz584qDSeqgb9fUyb+egRD/09Nt8tvVfFtqDSo9K4H6UlKQXN+v9qpbMuBhUqx6FyjzNypFbHnyCnQU9fXlXZh3ioGFKYSGVqDiBAvCvSG0r5bFTVvRzwFRQZahnjRpra0LqguKlzMHDx4kPvvv/+G+/38/Lh06VKVhBLVxLE/Yc9sQKPMk3G2kn94vEKVBpUBzSHnEsy+FxK2q53KNhTmwYapyvFdL4DTte3tF+4u3vFXJv7atIdLumnfwTLt3AI9c3cqrQse61pX/p5UIxUuZry8vDh//vwN9+/bt4/gYJmQJ8op8wKsmKgcd5oIYV3VzVNRbr4w7g8I7QT5GTDvfji+Su1U1i9mJmScVUbq2k4ovftQcjoHzqZjr9PIxF8bd0/zQHzdHbmQkc+qQxVbubp4TxJXcwoJ8Xamb9MAEyUUlqjCxczw4cN55ZVXSElJQaPRYDAY2LZtGy+++CJjxowxRUZha4xGpZDJuQz+zaDnG2onujNOnjB6CTToB0V5sPAhOLBI7VTWKy8DNn+iHHd/tcyGiSWjMn2bBsgyWxvnYKdlZPvibtoVmAisNxivtS7oHIZOWhdUKxUuZj744AMaNWpESEgIWVlZNGnShK5du9KpUydef/11U2QUtiZmJpz8G3SOyi6/dlb84WTvDA/OhxYPKpOYlzwK0d+qnco67ZgGuWngUx8iHiq9O6egiOX7ZOJvdfJQ+1DsdRr2JFzh4NnyLdNec+QC8Zdz8HS2Z2gbC1wRKUyqwsWMg4MD33//PadPn2blypXMnz+fY8eOMW/ePHQ6C9obRFimSydhdXHR2/tt8G+qapwqobOH+2ZAu8eVr/96GTZ+KP2cKiIrFbZPU457vQE6u9KHVh44T2Z+EbV9XOhY18Td04VF8HN34t4WQUD5R2e+L94kb1SHUFwd7f7l2cLW3PFPPDQ0lNBQ+S1JVIC+EH6bAEW5ULe70hHbVmi1EPURuHjDxqnKLfcK9J2qPCZub/Mnyu7PQa2g8cAyD5WsanmwbYh0Pa5Gxnaqw9J9yfy+/xxT7mlEzdtcXtyTkMaehCs46LSM7VjHfCGFxahwMWM0Glm8eDEbNmwgNTUVg6HsbPMlS5ZUWThhYzZ+COdjwckL7ptuex/yGo0y18O5hjI6Ez1DKWgGfaOM3pRTRl4hrg521eea/5V4iPlROe79dpnl+cdTMtmbeBU7rYYHWkvX4+qkZYgXLUO8iE26yoLoRJ7pVf+Wz/1+szJX5r7IIPw8nMwVUViQCn+aTJ48mdGjRxMXF4ebmxuenp5lbkLcVMIO2PqZcjzgC/AIUjWOSbV/HO7/DjQ6OPAL/DIaCnPL9dKktBy6fbyBbv/dwIkL1aQH1IapYCiEuj2UnZavU7Ljb+/G/vi5y4dUdfNw5zrA7Zdpx1/KZvURZdXThLtkk7zqqsIjM/PmzWPJkiXcc889psgjbFFeBix9DIwGiBgBTW/cp8jmRDwITh7w6zg48RfMHwIjFpTZN+Vmvtlwiis5hVzJKWTI9O18N7oNHevZ8DyRC4eVgg+g15tlHsor1LNk71kAhreTCZ3VUVSzQN5zP0pqZj5/HUphYMSNvwT9uC0OoxG6N/Slgb+7CimFJajwyIynpyd160r1Kypg1atwNVHZbC7qY7XTmE/DKBi1BBw9IGGbsrle1sVbPj0pLYfFe5QP7wb+bmTmFTH2x10sj7XhHlDr3gWM0OQ+CG5V5qG/Dp0nI6+IYC9n7qrvq0o8oS4HOy2jSrppb7uxm/aV7AIWxShd1B+TUZlqrcLFzNtvv80777xDbm75hs1FNXd4GcT+BBot3P+tMlpRndTpDGN/B5eakHIAZvVTCrubmL7pNEUGI13Ca7JiYheimgVQoDfw7MJYpm88jdHWVkcl7lRGrTQ66Hnjtg4LopUPqQfbhlSf+UPiBiXLtPcmXmV/0tUyj83fmUBeoYGmQR62PYIp/lWFi5lhw4Zx5coV/Pz8aN68Oa1atSpzE6JUxjlYOVk57vIc1O6kahzVBLVU2h94hsDlU/BjP7h4vMxTkq/m8mvxb5iTetXHyV7HNw+14pEuYQB8tOoYbyw/RFEFt3e3WEYjrH1bOY4cBTXLTu48lZrFrvg0tBoYJnuGVGu+7o4MKF6mPee6Zdp5hXrm7FC+ltYFosJzZsaOHcuePXsYNWoU/v7+8hdI3JzBAMueUlbzBEZAt1fVTqSumuFKx+1598OlE0pBM+q30ksrMzaeplBvpGNdn9ImilqthjfubUKwlzPv/nGE+TsTSUnP46sRkbg4WPk+Gif/hsQdYOekrAD7h1+Kd/zt2ciPAE+Z+Fvdje1UhyX7kvn9wDlevacRfu5OLNuXzKWsAoI8nbineaDaEYXKKvwv4h9//MHq1avp0qWLKfIIW7HrWzizAeycYfAPYOfw76+xdZ614OFV8NMQOLcP5gyAEQs4792WX3YrozLP9r5x+en4LmEEejox+ZdY1h5NZcR3O/lhbFt83a1052SDAda+oxy3f/yGlW35RfrSuUOy468AiAjxolWoF3sTr7IgOolneoaXbpI3vksY9job2+ZBVFiF/waEhITg4VHN5j2Iikk9CmveUo77vAu+DdTNY0lcfZQ5NGFdoSAL5j/AxmWzKNAbaBfmTYdb7HAb1TyQnx9tTw0Xe/afTWfw9G2cvphl5vBV5NBiSD0Mjp7QefIND/99+AJXcgoJ8HCiWwOZ+CsU4zorl1znRyfw95ELnL6YjbujHQ+2lcuQ4g6KmU8//ZSXX36Z+Ph4E8QRVq8oH357FPT5EH53mc7HopijOzz0KzS6F/T5DDvzfzyg28Tk22wKBtC6tje/PdmJUG8XktJyGTJ9OzHxaWYKXUWKCmD9e8pxl2eVHZP/oWRvmWFtQ7CT37hFsahmAfh7OHIxM5+XF+8HYET7UNydyr8hpbBdFf6XYtSoUWzYsIF69erh7u6Ot7d3mZuo5ta/BxcOgouPsvOtzKm6OXsnGDqHfT73oNMY+cT+WzqmLvzXl9X1dWPJU52ICPHiak4hD/0QzZ8Hz5shcBXZOweuJoCb/03bWcRfymb76ctoNDCsjez4K66x111bpp2RV4SdVsO4TnXUDSUsRoXnzHzxxRcmiCFsQtwW2P61cjzwa3D3VzePhUvNKWLEhVG8ADxq9yeav19TJkz3fP22RWBNN0cWPtqBZxbsY+3RCzz9815eu6ex5e9+mp8Fm4r3Ger2Mji43vCUhcVzh7rW96VWDRdzphNWYET7UL5ef4oCvYEBEUEEeTmrHUlYiDtazSTEDXKvwtInACO0GgON+qudyOJ9t+kMeUXwZ8jTTGjeGs36d2HLJ0pBc88nt+1d5eyg49vRrXnn98PM3ZHAe38cJflqLq/3b2K5e7LsnA7ZqVAjDFrd+O9IQZGBxXuUYkYm/oqbqenmyOPd6rJ4z1me7hGudhxhQcpVzGRkZJRO+s3IyLjtc2VycDX154uQcVb5oOo7Ve00Fu9SVj7zoxMAeLZ3AzQNu4CzF/zxIsTMVDaU828KPvXAux741FX+6+xV+h46rYZ3BjYl2MuZqX8dY9a2eM5fzeOL4S1xstep843dSvZl2P6Vctzz9Zs23lx39AKXsgqo6eZIr8Z+Zg4orMULfRryQp+GascQFqZcxUyNGjU4f/48fn5+eHl53XRvGaPRiEajQa/XV3lIYeEO/AoHf1V2ch38PTi6qZ3I4n2/+Qx5hQYiQryurdhpO0HpKL70CWW1T+rhG1/o7H1dgVMPjXddHg+vS8gD4UxeeoZVh1N46Htl6ba3qwUth9/6GeRnQEBzaDr4pk9ZUHyJaVibWrLUVghRIeUqZtavX186uXfWrFmEhISg05X9zc9gMJCYePNt2oUNu5oEf7ygHHd7GULaqpvHClzOymfujuJRmV7hZX85aP4AhHaA5D1w+TSknYbLZyDtDGSlQG4anE2Ds7vLvOc9wN3uPhzO8+H0eX+WfhnKwB5d8K3dWCl81GwjkX4Wdn2vHPd6+6aXz5LScthyUulbJUtthRAVVa5iplu3bqXH48ePLx2lud7ly5fp3bu3zKmpTgwGWPYk5KdDcBu460W1E1mFH7bGkVuop3mwJz0a3uRyimct5fZP+VlKUZN2Wvnv5eLjy6chOxX7vMu05DItdSegAFj907XXuvoqRY133WuXrHyKv3Y0cafhjR8qS/Vrd4HwXjd9yqKYJIxG6BJek9o+N04MFkKI26nwBOCSy0n/lJWVhZOTbDtereyYBvFbwN4VBn8HOivfYt8MrmQXMLe4v8ykXvUr1g7E0Q0CWyi3f8rPLC5wTpN1/jg7YmLwyk0kTHOBmpp0yL6o3JJ23vhaV79rl668w647rlv5S4YXTyiNRgF6v3XTVVpFekNp5+Ph7WRURghRceX+9Hn++ecB0Gg0vPHGG7i4XFs2qdfriY6OpmXLllUeUFiolIOw7j/Kcb+pygeg+Fczt8aRXaCnSaAHvatykquju9IDKzACt2bQqWsRT/+8l43HL+KhyeGD7m7cG5xzbTSnuPAh55Kywig7VemV9E9u/mUnIHvXvTaic5Ol1TdY/y4YDdCwP4S0u+lTNhy/yIWMfHxcHejTJKCSfxBCiOqo3MXMvn37AGVk5uDBgzg4XJtc6ODgQEREBC++KJcZqoXCXGWXX0Oh8iHVaozaiazC1ZwCZt/pqEwFuTra8cOYNry+7BALdycxcYOBg92a8ErfwWivX7qdl148N+fMtQKn5FJWzmXIuqDcErffeBL3QKWoKS1w6l372sEFzu6BoysADfR645ZZFxbv+DukdS0c7GTirxCi4spdzGzYsAGAhx9+mC+//FKWYFdna9+Bi0eVyxMDv5Jdfsvpx23xZOUX0SjAnT5NTL+hoJ1Oy9TBzalVw5lP/j7Bt5vOkHwll0+GRlxbuu3kqXTuLu7eXUbu1eJRnLjrJiMXFzu5aZB5XrklbLvxte5BYCxe2RgxAvwa3zTj+fRcNhxPBWC4TPwVQtyhCk9ymDVrlilyCGtxej1ET1eO7/sfuNZUN4+VSM8tZNa2OEAZldGaaWM7jUbDxJ71CfJy5uXFB1h54Dypmfl8N7o1Xi7/snTb2QuCWyu3f8pJU4qc6y9ZlRQ7eVch85zyPJ0jdH/1lqdYtPssBiO0D/Omrq8s6RdC3BmZsSnKLycNlj2lHLedAPXvVjePFZm1LY7MvCIa+rvTr6n554UMblULfw8nnpi3h11xaTwwYwezxrUlxPsOWwa4eCu3WrcqdIovW/mEQ43aN30LvcHIL7uVS0yy468QojLkArUoH6MRfn9WuazgUx/uflftRFYjI6+QH7cqozLP9Ao326jMP3UOr8mvT3YkwMOJU6lZDJ6+nUPJ6VV/IhdvqNUGWgy7+eWrYptPXuRceh6ezvb0ayYTf4UQd06KGVE++xcokzm1djDke2WCpyiXOdviycgrItzPjahmgapmaRTgwdKnO9EowJ2LmfkM+3ZH6ZwVc1sQrYzKDG4VbHntF4QQVkWKGfHv0uLgz5eU4x7/B0GR6uaxIln5RfxQMirTM9wimkAGejqz6ImOdA73IadAz4Q5MSzYZd7du1Mz8lh3TCmi5BKTEKKypJgRt2fQK72CCrIgtCN0nqx2IqsyZ3s86bmF1PV15d4WQWrHKeXhZM+sce0Y3CoYvcHIlCUH+fTv4xiNRrOc/9c9Z9EbjLSuXYMG/ibegVgIYfOkmBG3t/VzZddYB3e4/1vQyuWA8srOL+KHLWcAyxmVuZ6DnZZPh0YwqWc4AF+vP8ULi/ZTUGQw6XkNBiMLZeKvEKIKSTEjbi15L2ycqhzf899brkoRNzdvZwJXcgqp4+PCAAsalbmeRqPh+T4N+XBwc3RaDUv2JfPw7F1k5BWa7JzbT18mKS0Xdyc7+jdXdw6REMI2qFrMbN68mQEDBhAUFIRGo2HZsmVlHjcajbz55psEBgbi7OxM7969OXnypDphq5uCbFjyKBiKoMl9EDFc7URWJaegiO83K6MyE3vWx05n2b83DG8Xyg9j2+DioGPbqcsMm7GD8+m5JjlXyfyc+yODcXaQkT4hROWp+i9sdnY2ERERfPPNNzd9/OOPP+arr75ixowZREdH4+rqSt++fcnLyzNz0mro7zfg8illy/p7P5ddfivop52JXM4uINTbhftaWuaozD/1aOjHosc74uvuyLGUTO7/ZjtHz2dU6TkuZeXz95EUAIa3lUtMQoiqoWoxExUVxXvvvcf9999/w2NGo5EvvviC119/nUGDBtGiRQvmzp3LuXPnbhjBEVXsxGqImakc3zdd2TdElFtugZ5vN58GYGKPcIsflbles2BPlj7ViXA/N1Iy8hg6YwdbTl6ssvf/bc9ZCvVGIkK8aBIkLVGEEFXDYv+VjYuLIyUlhd69e5fe5+npSfv27dmx4ybdfYvl5+eTkZFR5iYqIOsiLH9aOe7wFNTroW4eK/TzrkQuZRVQq4Yz97cKVjtOhdWq4cJvT3SifZg3WflFPDxrN4v3nK30+xqNRhbuTgJghPRhEkJUIYstZlJSlKFof/+yDfn8/f1LH7uZqVOn4unpWXoLCZF/NMvNaITfJ0H2RfBtDL3eUjuR1ckr1DNjkzIq83SPcOytaFTmep4u9sx9pB0DIoIoMhh58df9fLXuZKWWbu88k0bcpWxcHXQMiLCOS29CCOtgnf/S3saUKVNIT08vvSUlJakdyXrsnQPH/wSdg7LLr72T2omszsJdiVzMzCfYy5khrWqpHadSHO10fPlgS57oVg+Az9ac4NXfDlKov7Ol2yXLsQe2DMbVUdrCCSGqjsUWMwEBSq+WCxculLn/woULpY/djKOjIx4eHmVuohwun4ZVU5TjXm9CQHN181ihvEI904tHZZ7sXg8HO4v936vctFoNr0Y14t1BTdFq4JeYJCbMiSErv6hC73Mlu4C/DiojqiPayWipEKJqWey/tmFhYQQEBLBu3brS+zIyMoiOjqZjx44qJrNB+kJlGXZhDtS5Czo8rXYiq7QoJokLGfkEejoxtI11j8r80+iOdfh2dBuc7LVsOnGRB7/dQWpG+VcVLtmXTIHeQNMgD5oHe5owqRCiOlK1mMnKyiI2NpbY2FhAmfQbGxtLYmIiGo2GyZMn895777FixQoOHjzImDFjCAoK4r777lMztu3Z/Akk7wEnT7h/Bmgttsa1WPlFeqZvVEZlnupeD0c729s/5e4m/ix8rCM+rg4cPpfB/f/bzskLmf/6OqPRyMLivWWGtwtFI8v8hRBVTNVPrZiYGCIjI4mMVBoXPv/880RGRvLmm28C8PLLL/PMM8/w2GOP0bZtW7Kysli1ahVOTjKXo8qc3w+b/6sc9/8MPG1rRMFcfo05y/n0PPw9HBnaxnYvo7QM8WLJU50Iq+lK8tVcBk/fzo7Tl2/7mj0JVziZmoWzvY5BVrLnjhDCumiM5uosp5KMjAw8PT1JT0+X+TM3s2gMHFmu7PI7bI7aaaxSQZGBHp9sJPlqLm8PaMK4zmFqRzK5tOwCHp0bw56EKzjotPx3aAsGtbz5MvQXFu3nt71nGdq6Fv8dGmHmpEIIa1WRz2+5nlCdpZ2Bo78rx91fVTeLFftt71mSr+bi6+7I8GrSONHb1YGfJrQnqlkABXoDzy6MZfrG0zcs3U7PLeSPg+cAGNG+evzZCCHMT4qZ6mzH/8BogPC7wa+x2mmsUqHewDcbTgHwRLd6ONnb3lyZW3Gy1zHtoVaMLx6J+mjVMd5Yfoii65ZuL49NJq/QQEN/dyJDvFRKKoSwdVLMVFc5abBvvnLc6Rl1s1ixpXuTOXsll5pujjxUTUZlrqfTanhzQBPeuLcJGg3M35nIE/P3kFNQhNFo5OdoZeLviHYhMvFXCGEyUsxUV7tnQlEuBEZAWFe101ilIr2BacWjMo93rVutO0A/0iWM/z3UCkc7LWuPpjLiu52sO5rKsZRMHO203B8pE8uFEKYjxUx1VJgHu75VjjtNko7Yd2hZ7DkS03LwcXVgZIfqNyrzT1HNA/n50fZ4udiz/2w6E+bGAHBP80A8XexVTieEsGVSzFRHBxYq/Zc8Q6DJILXTWKUivYFp608C8GjXurg4yPb8AK1re7PkyU6EeruU3jeiGl5+E0KYl/wLXN0YDLB9mnLc4SnQyW/Md+L3A+eIv5xDDRd7RneorXYci1LX140lT3XipV/34+lsT9s6NdSOJISwcVLMVDcnVsHlk+DoCa1Gq53GKukNRr5er8yVmXBXXWmaeBM13RyZ9XA7tWMIIaoJucxUCflFevIK9WrHqJjtXyv/bfMwOLqrm8VKrTxwjjMXs/FysWdspzpqxxFCiGpPipk7NHdHPB2nrmdBcc8Zq3A2BhK3g9Ye2j+hdhqrdP2ozCOdw3CTURkhhFCdFDN3SIOypfv8nQk37HpqsbZ/pfy3xTDwCFQ3i5X669B5TqVm4eFkx9jOddSOI4QQAilm7th9kcG4OOg4fTGbHWdu32jPIlzfuqDjRHWzWCmDwchX65QVTOO7hOHhJJOnhRDCEkgxc4fcney5P1JprPfTTiu41LRz+rXWBf5N1E5jlVYdTuHEhSzcnex4uBo0kxRCCGshxUwljCpekrv6cAqpGXkqp7kNaV1QadePyjzcOQxPZxmVEUIISyHFTCU0DvSgde0aFBmMLNydpHacW9s9EwpzIKCFtC64Q38fucCxlEzcHO0YL3NlhBDCokgxU0klG6Yt2JVYpluwxbi+dUHnZ6V1wR0wGq+NyozrVAcvFweVEwkhhLieFDOVFNU8AG9XB86n57H+WKracW4krQsqbe3RVI6cz8DVQccjXWSujBBCWBopZirJ0U7H0DZKR+B5OxNUTvMPZVoXPCmtC+7A9aMyYzrVoYarjMoIIYSlkWKmCoxsVxuNBracvET8pWy141xzcvV1rQvGqJ3GKm04nsrB5HSc7XVMkFEZIYSwSFLMVIFQHxe6NfAF4GdL2hF4W/EmedK64I4YjUa+XFs8KtOxNj5ujionEkIIcTNSzFSRUe2VicCLYpIso1+TtC6otE0nLrL/bDpO9loe7VpX7ThCCCFuQYqZKtKjkR/BXs5czSnkjwPn1Y5zraGktC64I0ajkS+L58qMal+bmjIqI4QQFkuKmSqi02p4qH0oAPOjVZ4InBYHR1cox9K64I5sPXWJfYlXcbTT8lg3GZURQghLJsVMFRrWJgR7nYZ9iVc5lJyuXpCd/ytuXdBbWhfcgevnyjzUPhQ/dyeVEwkhhLgdKWaqkK+7I/2aKZd0flJrdKZM64JJ6mSwcjtOXyYm4QoOdlqe6FZP7ThCCCH+hRQzVWxU8aWmZfvOkZFXaP4A0rqg0r4oniszom0I/h4yKiOEEJZOipkq1i7Mmwb+buQW6lmy56x5Ty6tCyptx+nL7IpLw0Gn5YnuMiojhBDWQIqZKqbRaEq7ac+PTsRoNJrv5NK6oNJKdvt9sG0IgZ7OKqcRQghRHlLMmMD9kcG4OOg4lZpFdFyaeU4qrQsqbVdcGjvOXMZep5FRGSGEsCJSzJiAu5M9g1oGA2bs1yStCyqtZFRmaJsQgr1kVEYIIayFFDMmMqqDMhF49aEUUjPzTH9CaV1QKXsS0th66hJ2Wg1PygomIYSwKlLMmEjTIE9ahXpRZDCyaHeSaU8mrQsq7ct1pwB4oHUtQrxdVE4jhBCiIqSYMaGSicA/RyeiN5hwIrC0LqiUfYlX2HziIjqthqe6h6sdRwghRAVJMWNC9zQPpIaLPefS81h/LNU0J5HWBZVW0oNpcGQwoT4yKiOEENZGihkTcrLXMaxNCADzTTURWFoXVMr+pKtsPK6MykzsKaMyQghhjaSYMbGS5pObTlwk4XJ21b65tC6otJIVTINaBlHbx1XlNEIIIe6EFDMmVtvHlW4NfAFl7kyVktYFlXIoOZ11x1LRamBiDxmVEUIIa2XxxUxmZiaTJ0+mdu3aODs706lTJ3bv3q12rAopmQi8KCaJvEJ91bzp9a0LOk2S1gV3oGSuzMCIIOr6uqmcRgghxJ2y+GJmwoQJrFmzhnnz5nHw4EH69OlD7969SU5OVjtaufVs5EeQpxNXcgr58+D5qnnTA79ca13Q9L6qec9q5PC5dNYcuYBGAxN71lc7jhBCiEqw6GImNzeX3377jY8//piuXbsSHh7O22+/TXh4ONOnT1c7XrnptJrSuTNVMhHYYLi2HFtaF9yRr4v3lbm3RRDhfjIqI4QQ1syii5mioiL0ej1OTk5l7nd2dmbr1q03fU1+fj4ZGRllbpZgWNsQ7LQa9iZe5fC59Mq9mbQuqJSj5zNYdTgFjQaekRVMQghh9Sy6mHF3d6djx468++67nDt3Dr1ez/z589mxYwfnz9/8cs3UqVPx9PQsvYWEhJg59c35uTvRt1kAAPN3VnIicMmojLQuuCPT1iujMvc0C6SBv/z5CSGEtbPoYgZg3rx5GI1GgoODcXR05KuvvmLEiBFotTePPmXKFNLT00tvSUkmbiVQAaOLJwIvj00mM6/wzt7k7B5I2FbcuuDxKkxXPZy4kMmfh5RC+JleMiojhBC2wOKLmXr16rFp0yaysrJISkpi165dFBYWUrdu3Zs+39HREQ8PjzI3S9E+zJv6fm7kFOhZuu8OJzBvL24o2XwoeARVXbhq4uv1pzAaIapZAI0CLOfvhhBCiDtn8cVMCVdXVwIDA7ly5QqrV69m0KBBakeqMI1Gw8jiicDzdiRgNFawX9P1rQs6PVPF6WzfqdRMVh44B8AzsoJJCCFshsUXM6tXr2bVqlXExcWxZs0aevToQaNGjXj44YfVjnZHBreuhbO9jpOpWeyKS6vYi6V1QaVMKx6V6dPEnyZBMiojhBC2wuKLmfT0dJ5++mkaNWrEmDFj6NKlC6tXr8be3jqXI3s42XNfpHJ5aH5FdgQu07pARmUq6szFLFbsV0ZlJvWSURkhhLAldmoH+DfDhg1j2LBhaseoUiPb12bBriRWHTrPxcwm+Lo7/vuLYq5vXdDN9CFtzLQNpzAYoXdjP5oFe6odRwghRBWy+JEZW9Qs2JPIUC8K9UYWxZRjtVVhHkR/pxxL64IKi7+UzfJYGZURQghbJcWMSka1V5Zp/xydiN7wLxOBD/wC2angUUtaF9yBaRtOoTcY6dHQlxa1vNSOI4QQoopJMaOS/i0C8XKxJ/lqLhuOpd76iQYD7JimHHd8SloXVFDi5ZzSZfAyKiOEELZJihmVONnrGNq6FgDzo2/Tr+nkarh0QloX3KFvikdlujbwJTK0htpxhBBCmIAUMyoaWXypadOJiyRezrn5k0pbF4yT1gUVlJSWw297zwLwrIzKCCGEzZJiRkV1arpyV/2aGI3w066bjM6UaV3whPkDWrn/bTxNkcFIl/CatK4tozJCCGGrpJhR2ajifk2/xpwlv0hf9kFpXXDHkq/msniPslLs2d4yKiOEELZMihmV9WrkR6CnE2nZBfx1MOXaA2VaF0xUJ5wVm77xFIV6Ix3r+tC2jrfacYQQQpiQFDMqs9NpGdGuuF/TzusuNe2cfl3rgqYqpbNO59NzWbS7eK6MjMoIIYTNk2LGAgxvG4KdVsOehCscPZ9R3LpgnvKgtC6osBkbT1OgN9A+zJsOdX3UjiOEEMLEpJixAH4eTvRtGgDA/J0J17UuaC6tCyroQkYeC3YXz5WRFUxCCFEtSDFjIUZ2UC41/bkvDkNp64JnpXVBBc3YdJqCIgNt69SgYz0ZlRFCiOpAihkL0bGuD/V8Xemj34xWWhfckdSMPH4u7kQ+qVd9NFIICiFEtSDFjIXQaDSMah/Co7o/ADB2eEJaF1TQd5vPkF9koFWoF13Ca6odRwghhJlIMWNBhnkeJVx7jgyjC3t9B6kdx6pcyMgrbQshozJCCFG9SDFjQVxj/gfAz/pezIm5rHIa62EwGHl+USx5hQYiQ73o1sBX7UhCCCHMSIoZS1HcusCgtWdWUV/+OnSeS1n5aqeyCjM2n2bbqcs42+v4ZGiEjMoIIUQ1I8WMpdihNJTUNh9KQEhdCvVGFsUkqRzK8u1NvMKnf58A4J1BTann66ZyIiGEEOYmxYwlSIuDI8uV404TGdVeWab9085E9AajisEsW3puIZMW7ENvMDIgIoihrWupHUkIIYQKpJixBCWtC+r1Av+mDIgIwtPZnuSruWw6kap2OotkNBp5belBzl7JJcTbmffvbyaXl4QQopqSYkZt17cu6DwJACd7Xekow/ydiWols2iLYpJYeeA8dloNXw2PxMNJlrELIUR1JcWM2m7RumBkh9oAbDieSlJajlrpLNKp1EzeXnEEgBf6NCQytIbKiYQQQqhJihk1FeZBaeuCSWVaF4TVdOWu+jUxGuHnXTI6UyKvUM/En/eRW6inS3hNHu9aV+1IQgghVCbFjJoOLoLS1gX33/DwyPbK6Myi3UnkF+nNnc4iTf3zKMdSMvFxdeCzYRFotTJPRgghqjspZtRiMMB2ZTk2HZ68aeuC3o39CPBw4nJ2AasOpZg5oOVZc+QCc3You/x+MiwCPw8nlRMJIYSwBFLMqOXk33DpBDh6QKsxN32KnU7LiHbKMu35OxPMmc7inE/P5aXF+wGY0CWMHg39VE4khBDCUkgxo5aSUZk2D4OTxy2fNrxdCDqtht3xVziWkmGmcJZFbzAyeWEsV3MKaR7sycv9GqkdSQghhAWRYkYNyXsgYSto7aH9E7d9qr+HE32a+APVd3Tmmw2niI5Lw9VBx1cjInGwk7+2QgghrpFPBTWUjMo0HwoeQf/69NHFy7SX7k0mK7/IlMkszu74NL5Yq7QrePe+ZoTVdFU5kRBCCEsjxYy5XYkv07qgPDrW86GuryvZBXqW7Us2XTYLk55TyLML9mEwwuDIYAa3knYFQgghbiTFjLnt+F+Z1gXlodFoSpdpz9+ZgNFo+/2ajEYjr/x2gHPpedTxceE/9zVTO5IQQggLJcWMOd2kdUF5PdCqFk72Wo6lZLIn4YoJwlmWn3clsupwCvY6DV+PaIWbo53akYQQQlgoKWbMKebHm7YuKA9PF3sGRijza2x9IvDxlEz+87vSruCVfo1oXstT5URCCCEsmRQz5lKYB9HfKsf/aF1QXqOKJwL/eTCFy1n5VZnOYuQW6HlmwV7yiwx0a+DL+M5hakcSQghh4aSYMZd/aV1QHi1qeRFRy5MCvYFFMWerOKBleO+PI5y4kIWvuyOfSrsCIYQQ5SDFjDkYDLB9mnJ8i9YF5VXSTfvnXQnoDbY1Efivg+f5KToRjQY+H9aSmm6OakcSQghhBaSYMYeTf8Ol47dtXVBeA1oE4eFkR1JaLptPXKyigOo7eyWHV347AMDjXevRpX5NlRMJIYSwFhZdzOj1et544w3CwsJwdnamXr16vPvuu9a3NLmcrQvKw9lBx9A2IYDtTAQu0huYvDCWjLwiIkK8eKFPA7UjCSGEsCIWXcx89NFHTJ8+nWnTpnH06FE++ugjPv74Y77++mu1o5VfaesCu39tXVBeI9srzSfXH08lKS2nSt5TTV+tO0lMwhXcHe34engk9jqL/msphBDCwlj0p8b27dsZNGgQ/fv3p06dOjzwwAP06dOHXbt23fI1+fn5ZGRklLmpqoKtC8qjrq8bncN9MBphwa7EKnlPtew4fZmvN5wC4P3BzQn1cVE5kRBCCGtj0cVMp06dWLduHSdOKL159u/fz9atW4mKirrla6ZOnYqnp2fpLSQkxFxxb1SmdcEzVfrWJf2aFsUkUVBkqNL3Npcr2QU890ssRiMMa1OrdB8dIYQQoiIsuph59dVXGT58OI0aNcLe3p7IyEgmT57MyJEjb/maKVOmkJ6eXnpLSkoyY+J/2Dm9wq0Lyqt3Y3/8PRy5lFXAqsMpVfre5mA0Gnlp8X5SMvKo6+vK2wOr9s9HCCFE9WHRxcyiRYv46aef+Pnnn9m7dy9z5szhk08+Yc6cObd8jaOjIx4eHmVuqshJg71zleMqHpUBsNNpGd5WmTszf4f1TQSeuyOBtUdTcdBp+XpEJC4O0q5ACCHEnbHoYuall14qHZ1p3rw5o0eP5rnnnmPq1KlqR/t317cuqNvdJKcY0S4UnVbDrvg0jqdkmuQcpnDkXAbv/3kUgCn3NKJpkLQrEEIIcecsupjJyclBqy0bUafTYTBY+ByRovxKty4ojwBPJ+5u7A/AT9HWMTqTU1DEMwv2UlBkoHdjP8Z1qqN2JCGEEFbOoouZAQMG8P777/PHH38QHx/P0qVL+eyzz7j//jtrB2A2B36pdOuC8irp17RkbzLZ+UUmPVdVeGfFEU5fzMbfw5GPH4hAY6JCTwghRPVh0cXM119/zQMPPMBTTz1F48aNefHFF3n88cd599131Y52a1XYuqA8OtXzoW5NV7Lyi1gWm2zSc1XW7/vP8UtMktKu4MGWeLs6qB1JCCGEDbDoYsbd3Z0vvviChIQEcnNzOX36NO+99x4ODhb8IXhqTZW1LigPrVbDQ8Wb6M3bkWCxuyMnpeXwf0sOAjCxRzid6km7AiGEEFXDoosZq7TtK+W/rcdVunVBeT3QuhaOdlqOpWSyN/GKWc5ZEYV6A88s2EdmfhGta9fg2V711Y4khBDChkgxU5Wub13Q4UmzndbLxaF0w7n5Oy1vR+DP15wgNukqHk52fDm8JXbSrkAIIUQVkk+VqlQyV6YKWxeUV8lE4D8OnCctu8Cs576dbacuMX3TaQA+HNKCWjWkXYEQQoiqJcVMVbkSD0eWKccdJ5r99BEhXjQP9qRAb2BRjIq7Hl/nUlY+k4vbFYxoF8o9zQPVjiSEEMIGSTFTVa5vXRDQTJUIJf2afo5OxGBQdyKwwWDkxV/3czEznwb+brx5bxNV8wghhLBdUsxUhZw02DtPOTZB64LyGhARhIeTHYlpOWw+eVG1HAA/botj4/GLONpp+XpEK5wddKrmEUIIYbukmKkKMT9CYbZJWxeUh7ODjiGtawEwf6d6OwIfSk7no1XHAHj93iY0DHBXLYsQQgjbJ8VMZZmpdUF5lUwEXn8sleSruWY/f1Z+Ec8s2Eeh3kjfpv6MKt4DRwghhDAVKWYq68Ci4tYFwSZvXVAe9Xzd6FTPB4MRFkSbf5n2m8sPEXcpmyBPJz4a0kLaFQghhDA5KWYqw2CA7V8rx2ZoXVBeJaMzC3cnUlBkvqacS/edZcneZLQa+GJ4JF4uFrxTsxBCCJshxUxllGldMFbtNKXubuKPn7sjl7IKWH04xSznjL+UzetLDwHwbK8GtAvzNst5hRBCCClmKqNkVMaMrQvKw16nZXg7Za6KOSYCFxQZmLRwH9kFetqFeTOxZ7jJzymEEEKUkGLmTiXvhfgtSuuC9k+oneYGI9qFoNNqiI5L48SFTJOe65O/j3PgbDpeLvZ8ObwlOq3MkxFCCGE+Uszcqd0/KP9tPhQ8g9XNchOBns70buwHwE8mHJ3ZeDyV7zafAeDjIS0I9HQ22bmEEEKIm5Fi5k7d81+I+q+yHNtClUwEXrI3mez8oip//9TMPF78dT8AYzrWpk/TgCo/hxBCCPFvpJi5Uw6u0P4x8Lfcbfo716tJHR8XMvOLWB57rkrf22Aw8sKi/VzKKqBRgDv/d0/jKn1/IYQQorykmLFhWq2mdHRm/s4EjMaq69f03ZYzbDl5CSd7LdMeisTJXtoVCCGEUIcUMzbugda1cLTTcuR8BvuSrlbJe8YmXeWT1ccBeHtAU8L9pF2BEEII9UgxY+O8XBy4t0UQAPN3VH4icGZeIZMW7KPIYKR/i0AebBtS6fcUQgghKkOKmWpgdEflUtPKg+e5kl1wx+9jNBp5bekhEtNyCPZy5oP7m0u7AiGEEKqTYqYaiKjlSbNgDwqKDPy6J+mO32fxnrOs2H8OnVbDVyMi8XS2jPYNQgghqjcpZqoBjUbDqPbK6MxP0YkYDBWfCHz6YhZvLj8MwPN3N6B17RpVmlEIIYS4U1LMVBMDWwbh7mRHwuUctpy6VKHX5hfpeebnfeQW6ulUz4cnutUzUUohhBCi4qSYqSZcHOwY0qoWUPF+TR/+dYwj5zPwdnXg8welXYEQQgjLIsVMNTKqg9J8ct3RCyRfzS3Xa9YdvcCsbfEAfDK0Bf4eTqaKJ4QQQtwRKWaqkXA/dzrU9cZghIW7Ev/1+Rcy8nhp8QEAxncOo2cjf1NHFEIIISpMiplqZnSHOgAs3J1EQZHhls/TG4xMXhhLWnYBTYM8eCWqoZkSCiGEEBUjxUw106epP77ujlzMzOfvIym3fN6MTafZceYyLg46vh4RiaOdtCsQQghhmaSYqWbsdVqGF+/ae6uJwHsS0vhszQkA/jOoGXV93cyWTwghhKgoKWaqoRHtQtFqYOeZNE6lZpZ5LD23kEkLYtEbjAxqGcSQVsEqpRRCCCHKR4qZaijIy5lejZXJvPN3XpsIbDQa+b8lB0m+mkttHxfeu6+ZtCsQQghh8aSYqaZGdVB2BP5tz1lyCooAZVLwHwfPY6fV8NXwSNydpF2BEEIIyyfFTDV1V3hNavu4kJlfxIrYc5y8kMk7vyvtCl7q25CIEC91AwohhBDlJMVMNaXVahjZXtlEb/b2eJ5ZsI+8QgN31a/Jo3fVVTmdEEIIUX5SzFRjQ1uH4GCn5VhKJsdSMqnp5sCnwyLQSrsCIYQQVkSKmWqshqsD97YILP36s2Et8XOXdgVCCCGsi53aAYS6nupej5j4KwxvF0LXBr5qxxFCCCEqzOJHZurUqYNGo7nh9vTTT6sdzSaE+7mz+eUePNU9XO0oQgghxB2x+JGZ3bt3o9frS78+dOgQd999N0OHDlUxlRBCCCEshcUXM76+ZS99fPjhh9SrV49u3brd9Pn5+fnk5+eXfp2RkWHSfEIIIYRQl8VfZrpeQUEB8+fPZ/z48bfcmXbq1Kl4enqW3kJCQsycUgghhBDmpDEajUa1Q5TXokWLeOihh0hMTCQoKOimz7nZyExISAjp6el4eHiYK6oQQgghKiEjIwNPT89yfX5b/GWm682cOZOoqKhbFjIAjo6OODo6mjGVEEIIIdRkNcVMQkICa9euZcmSJWpHEUIIIYQFsZo5M7NmzcLPz4/+/furHUUIIYQQFsQqihmDwcCsWbMYO3YsdnZWM5gkhBBCCDOwimJm7dq1JCYmMn78eLWjCCGEEMLCWMUwR58+fbCiRVdCCCGEMCOrGJkRQgghhLgVKWaEEEIIYdWkmBFCCCGEVZNiRgghhBBWzSomAFdGycRhaTgphBBCWI+Sz+3yLACy+WImMzMTQBpOCiGEEFYoMzMTT0/P2z7HqhpN3gmDwcC5c+dwd3e/Zaft6q6kGWdSUpI047QA8vOwLPLzsCzy87Aspvx5GI1GMjMzCQoKQqu9/awYmx+Z0Wq11KpVS+0YVsHDw0P+cbAg8vOwLPLzsCzy87Aspvp5/NuITAmZACyEEEIIqybFjBBCCCGsmhQzAkdHR9566y0cHR3VjiKQn4elkZ+HZZGfh2WxlJ+HzU8AFkIIIYRtk5EZIYQQQlg1KWaEEEIIYdWkmBFCCCGEVZNiRgghhBBWTYqZamrq1Km0bdsWd3d3/Pz8uO+++zh+/LjasUSxDz/8EI1Gw+TJk9WOUq0lJyczatQofHx8cHZ2pnnz5sTExKgdq1rS6/W88cYbhIWF4ezsTL169Xj33XfL1bdHVN7mzZsZMGAAQUFBaDQali1bVuZxo9HIm2++SWBgIM7OzvTu3ZuTJ0+aLZ8UM9XUpk2bePrpp9m5cydr1qyhsLCQPn36kJ2drXa0am/37t18++23tGjRQu0o1dqVK1fo3Lkz9vb2/PXXXxw5coRPP/2UGjVqqB2tWvroo4+YPn0606ZN4+jRo3z00Ud8/PHHfP3112pHqxays7OJiIjgm2++uenjH3/8MV999RUzZswgOjoaV1dX+vbtS15enlnyydJsAcDFixfx8/Nj06ZNdO3aVe041VZWVhatWrXif//7H++99x4tW7bkiy++UDtWtfTqq6+ybds2tmzZonYUAdx77734+/szc+bM0vuGDBmCs7Mz8+fPVzFZ9aPRaFi6dCn33XcfoIzKBAUF8cILL/Diiy8CkJ6ejr+/P7Nnz2b48OEmzyQjMwJQ/uIBeHt7q5ykenv66afp378/vXv3VjtKtbdixQratGnD0KFD8fPzIzIyku+//17tWNVWp06dWLduHSdOnABg//79bN26laioKJWTibi4OFJSUsr8u+Xp6Un79u3ZsWOHWTLYfKNJ8e8MBgOTJ0+mc+fONGvWTO041dbChQvZu3cvu3fvVjuKAM6cOcP06dN5/vnn+b//+z92797NpEmTcHBwYOzYsWrHq3ZeffVVMjIyaNSoETqdDr1ez/vvv8/IkSPVjlbtpaSkAODv71/mfn9//9LHTE2KGcHTTz/NoUOH2Lp1q9pRqq2kpCSeffZZ1qxZg5OTk9pxBEqR36ZNGz744AMAIiMjOXToEDNmzJBiRgWLFi3ip59+4ueff6Zp06bExsYyefJkgoKC5Och5DJTdTdx4kRWrlzJhg0bqFWrltpxqq09e/aQmppKq1atsLOzw87Ojk2bNvHVV19hZ2eHXq9XO2K1ExgYSJMmTcrc17hxYxITE1VKVL299NJLvPrqqwwfPpzmzZszevRonnvuOaZOnap2tGovICAAgAsXLpS5/8KFC6WPmZoUM9WU0Whk4sSJLF26lPXr1xMWFqZ2pGqtV69eHDx4kNjY2NJbmzZtGDlyJLGxseh0OrUjVjudO3e+YbuCEydOULt2bZUSVW85OTlotWU/snQ6HQaDQaVEokRYWBgBAQGsW7eu9L6MjAyio6Pp2LGjWTLIZaZq6umnn+bnn39m+fLluLu7l17X9PT0xNnZWeV01Y+7u/sN85VcXV3x8fGReUwqee655+jUqRMffPABw4YNY9euXXz33Xd89913akerlgYMGMD7779PaGgoTZs2Zd++fXz22WeMHz9e7WjVQlZWFqdOnSr9Oi4ujtjYWLy9vQkNDWXy5Mm899571K9fn7CwMN544w2CgoJKVzyZnFFUS8BNb7NmzVI7mijWrVs347PPPqt2jGrt999/NzZr1szo6OhobNSokfG7775TO1K1lZGRYXz22WeNoaGhRicnJ2PdunWNr732mjE/P1/taNXChg0bbvqZMXbsWKPRaDQaDAbjG2+8YfT39zc6Ojoae/XqZTx+/LjZ8sk+M0IIIYSwajJnRgghhBBWTYoZIYQQQlg1KWaEEEIIYdWkmBFCCCGEVZNiRgghhBBWTYoZIYQQQlg1KWaEEEIIYdWkmBFCCCGEVZNiRghhFcaNG2e+rdGFEFZFdgAWQliF9PR0jEYjXl5eakcRQlgYKWaEEEIIYdXkMpMQwqIsXryY5s2b4+zsjI+PD7179yY7O7vMZab4+Hg0Gs0Nt+7du5e+z9atW7nrrrtwdnYmJCSESZMmkZ2drc43JYQwKSlmhBAW4/z584wYMYLx48dz9OhRNm7cyODBg/nnAHJISAjnz58vve3btw8fHx+6du0KwOnTp+nXrx9DhgzhwIED/PLLL2zdupWJEyeq8W0JIUxMLjMJISzG3r17ad26NfHx8dSuXbvMY+PGjePq1assW7aszP15eXl0794dX19fli9fjlarZcKECeh0Or799tvS523dupVu3bqRnZ2Nk5OTOb4dIYSZ2KkdQAghSkRERNCrVy+aN29O37596dOnDw888AA1atS45WvGjx9PZmYma9asQatVBpv379/PgQMH+Omnn0qfZzQaMRgMxMXF0bhxY5N/L0II85FiRghhMXQ6HWvWrGH79u38/ffffP3117z22mtER0ff9Pnvvfceq1evZteuXbi7u5fen5WVxeOPP86kSZNueE1oaKjJ8gsh1CGXmYQQFkuv11O7dm2ef/55Dhw4UOYy02+//caIESP466+/6NWrV5nXjRw5kgsXLrB27VoVUgshzE0mAAshLEZ0dDQffPABMTExJCYmsmTJEi5evHjDZaFDhw4xZswYXnnlFZo2bUpKSgopKSmkpaUB8Morr7B9+3YmTpxIbGwsJ0+eZPny5TIBWAgbJcWMEMJieHh4sHnzZu655x4aNGjA66+/zqeffkpUVFSZ58XExJCTk8N7771HYGBg6W3w4MEAtGjRgk2bNnHixAnuuusuIiMjefPNNwkKClLj2xJCmJhcZhJCCCGEVZORGSGEEEJYNSlmhBBCCGHVpJgRQgghhFWTYkYIIYQQVk2KGSGEEEJYNSlmhBBCCGHVpJgRQgghhFWTYkYIIYQQVk2KGSGEEEJYNSlmhBBCCGHVpJgRQgghhFX7f/7EuIfsOez2AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "\n",
+    "df = pd.DataFrame(d)\n",
+    "sns.lineplot(data=df, x='size', y='time', hue='type')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I'm currently participating in Kaggle S3 E5, and I came across this class which I found very useful. But it also slows down the training by a lot because it needs to fit $k-1$ classifiers for the $k$ classes.

I tried to partly improve this by editing the `predict_proba` function by using vectorized operations, since it previously used a for loop + append operations which is notoriously very slow. I've tested this in my environment and the speedup is great.

Also since I was there I added a `set_params` method which I had the need for my RF hypeparameter tuning, and I think it might be useful.

Finally I edited a bit the style of the fit function, without changing its behaviour just to implement some good practices like less-nested for loops and declaring all the class properties in the `__init__` method.

